### PR TITLE
fix: 회사 샘플 데이터 누락으로 인한 빌드 실패 이슈

### DIFF
--- a/src/test/resources/sql/company-delete.sql
+++ b/src/test/resources/sql/company-delete.sql
@@ -1,0 +1,28 @@
+INSERT INTO company_id
+VALUES (UNHEX('0196f7a610b67123a2dc32c3861ea55e'));
+
+-- 2. 그 ID를 참조해서 실제 company 테이블에 insert
+INSERT INTO company (id,
+                     name,
+                     contact_phone_number,
+                     business_number,
+                     address,
+                     contact_email,
+                     detail,
+                     logo_image_path,
+                     type,
+                     deleted,
+                     created_at,
+                     modified_at)
+VALUES (UNHEX('0196f7a610b67123a2dc32c3861ea55e'),
+        '테스트회사',
+        '010-1234-5678',
+        '123-45-67890',
+        '서울시 테스트구',
+        'test@company.com',
+        '삭제 테스트용',
+        'path/logo.png',
+        'DEV',
+        false,
+        NOW(),
+        NOW());


### PR DESCRIPTION

## 📌 개요

- company-delete.sql 샘플 데이터 누락으로 인한 빌드 실패

## 🛠️ 변경 사항

- 원인 : company-delete.sql 누락으로 인한 테스트 실패
- 접근 : company-delete.sql 추가

## ✅ 주요 체크 포인트

- [x] 리뷰어가 중점적으로 봐야 할 부분이 있다면 적어주세요.

## 🔁 테스트 결과

- 어떻게 테스트했는지, 테스트 결과는 어땠는지 설명해주세요.

## 🔗 연관된 이슈

- #6 

<br>

## 📑 레퍼런스
