### PR TITLE
Build #21

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -35,6 +35,7 @@ repositories {
 
 ext {
     set('snippetsDir', file("build/generated-snippets"))
+    set('testcontainers.version', "1.19.8")
 }
 
 dependencies {
@@ -59,7 +60,13 @@ dependencies {
     testImplementation 'com.epages:restdocs-api-spec-mockmvc:0.19.2'
     implementation 'org.springdoc:springdoc-openapi-ui:1.8.0'
 
+    // uuid
     implementation 'com.fasterxml.uuid:java-uuid-generator:5.1.0'
+
+    // Test Container
+    testImplementation("org.springframework.boot:spring-boot-testcontainers")
+    testImplementation("org.testcontainers:junit-jupiter")
+    testImplementation("org.testcontainers:mysql")
 }
 
 openapi3 {

--- a/src/test/java/kr/mywork/base/test_container/RdbTestContainerConfig.java
+++ b/src/test/java/kr/mywork/base/test_container/RdbTestContainerConfig.java
@@ -1,0 +1,37 @@
+package kr.mywork.base.test_container;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.testcontainers.containers.MySQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.DockerImageName;
+
+import jakarta.annotation.PreDestroy;
+
+@Testcontainers
+@Configuration
+public class RdbTestContainerConfig {
+
+	@Container
+	static MySQLContainer<?> MYSQL_CONTAINER = new MySQLContainer<>(DockerImageName.parse("mysql:8.0"));
+
+	static {
+		MYSQL_CONTAINER.start();
+	}
+
+	@DynamicPropertySource
+	static void configureProperties(DynamicPropertyRegistry registry) {
+		registry.add("spring.datasource.url", MYSQL_CONTAINER::getJdbcUrl);
+		registry.add("spring.datasource.username", MYSQL_CONTAINER::getUsername);
+		registry.add("spring.datasource.password", MYSQL_CONTAINER::getPassword);
+	}
+
+	@PreDestroy
+	void preDestroy() {
+		if (MYSQL_CONTAINER.isRunning()) {
+			MYSQL_CONTAINER.stop();
+		}
+	}
+}

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -1,0 +1,11 @@
+spring:
+  jpa:
+    show-sql: true
+    open-in-view: false
+    hibernate:
+      ddl-auto: create
+  datasource:
+    url: jdbc:tc:mysql:8://mywork_rdb
+    username: root
+    password: cooper2025
+    driver-class-name: org.testcontainers.jdbc.ContainerDatabaseDriver


### PR DESCRIPTION
## 📌 개요

테스트 컨테이너 도입

## 🛠️ 변경 사항

- 기존 local rdb container 에 의존하던 환경을 테스트 독립적인 환경으로 변경

## ✅ 주요 체크 포인트

- [x] build.gradle 내부 testcontainer 의존성 확인
- [x] RdbTestContainerConfig 설정 확인

## 🔁 테스트 결과

- 테스트 컨테이너 도입 후, 기존 테스트 전체 성공 확인

![image](https://github.com/user-attachments/assets/663ea593-cfd1-4c95-b687-f4299c4dd003)


## 🔗 연관된 이슈

- #21 

<br>

## 📑 레퍼런스

- https://dev-cooper.tistory.com/67