### PR TITLE
[chore] intellij 에서 messages.properties 한글 텍스트 깨지는 문제

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,5 @@
 /gradlew text eol=lf
 *.bat text eol=crlf
 *.jar binary
+
+*.properties text working-tree-encoding=utf-8


### PR DESCRIPTION
## 📌 개요

- 커밋을 받은 branch 에서 properties 파일의 한글 텍스트가 깨지는 문제

## 🛠️ 변경 사항
- .gitattributes utf-8 설정 추가

## ✅ 주요 체크 포인트

- 인텔리제이에서 한글이 정상적으로 출력되는지 확인 필요
   - 이후 커밋되는 한글 텍스트 데이터에서 한글 텍스트가 정상 적용될 경우, 이전 데이터 한글로 전환 예정

## 🔁 테스트 결과

![image](https://github.com/user-attachments/assets/7690f80e-ab69-4c62-be12-8d0264bfdfed)


## 🔗 연관된 이슈

- #35 
