### PR TITLE
[feat] Member 도메인 및 Repository 구현

### DIFF
--- a/src/main/java/kr/mywork/domain/member/model/Member.java
+++ b/src/main/java/kr/mywork/domain/member/model/Member.java
@@ -1,0 +1,49 @@
+package kr.mywork.domain.member.model;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.Id;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.UUID;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class Member {
+
+	@Id
+	private UUID id;
+
+	@Column(name = "company_id", nullable = false)
+	private UUID companyId;
+
+	@Column(length = 30, nullable = false)
+	private String name;
+
+	@Column(length = 100)
+	private String department;
+
+	@Column(length = 50)
+	private String position;
+
+	@Enumerated(EnumType.STRING)
+	@Column(nullable = false)
+	private MemberRole role;
+
+	@Column(length = 300)
+	private String phoneNumber;
+
+	@Column(length = 300, unique = true, nullable = false)
+	private String email;
+
+	@Column(length = 300, nullable = false)
+	private String password;
+
+	@Column(nullable = false)
+	private boolean deleted;
+}

--- a/src/main/java/kr/mywork/domain/member/model/MemberRole.java
+++ b/src/main/java/kr/mywork/domain/member/model/MemberRole.java
@@ -1,0 +1,25 @@
+package kr.mywork.domain.member.model;
+
+import java.util.Arrays;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum MemberRole {
+	ANONYMOUS("ROLE_ANONYMOUS"),
+	USER("ROLE_USER"),
+	DEV_ADMIN("ROLE_DEV_ADMIN"),
+	CLIENT_ADMIN("ROLE_CLIENT_ADMIN"),
+	SYSTEM_ADMIN("ROLE_SYSTEM_ADMIN");
+
+	private final String roleName;
+
+	public static MemberRole of(final String inputRole) {
+		return Arrays.stream(values())
+			.filter(role -> role.getRoleName().equalsIgnoreCase(inputRole))
+			.findFirst()
+			.orElseThrow(() -> new IllegalArgumentException("invalid role name: " + inputRole));
+	}
+}

--- a/src/main/java/kr/mywork/domain/member/repository/MemberRepository.java
+++ b/src/main/java/kr/mywork/domain/member/repository/MemberRepository.java
@@ -1,0 +1,9 @@
+package kr.mywork.domain.member.repository;
+
+import kr.mywork.domain.member.model.Member;
+
+import java.util.Optional;
+
+public interface MemberRepository{
+    Optional<Member> findByEmailAndDeletedFalse(String email);
+}

--- a/src/main/java/kr/mywork/infrastructure/member/rdb/JpaMemberRepository.java
+++ b/src/main/java/kr/mywork/infrastructure/member/rdb/JpaMemberRepository.java
@@ -1,0 +1,11 @@
+package kr.mywork.infrastructure.member.rdb;
+
+import kr.mywork.domain.member.model.Member;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+import java.util.UUID;
+
+public interface JpaMemberRepository extends JpaRepository<Member, UUID> {
+    Optional<Member> findByEmailAndDeletedFalse(String email);
+}

--- a/src/main/java/kr/mywork/infrastructure/member/rdb/QueryDslMemberRepository.java
+++ b/src/main/java/kr/mywork/infrastructure/member/rdb/QueryDslMemberRepository.java
@@ -1,0 +1,22 @@
+package kr.mywork.infrastructure.member.rdb;
+
+import kr.mywork.domain.member.model.Member;
+import kr.mywork.domain.member.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+@RequiredArgsConstructor
+public class QueryDslMemberRepository implements MemberRepository {
+
+    private final JpaMemberRepository jpaMemberRepository;
+
+    @Override
+    public Optional<Member> findByEmailAndDeletedFalse(String email) {
+        return jpaMemberRepository.findByEmailAndDeletedFalse(email);
+    }
+
+
+}


### PR DESCRIPTION
## 📌 개요

- 회원 도메인 및 역할 Enum을 정의하고, 이를 기반으로 JPA 및 QueryDSL 리포지토리를 구현했습니다.

## 🛠️ 변경 사항
- Member.java: 사용자 정보 엔티티 정의
- MemberRole.java: ROLE_prefix를 포함한 역할 Enum 정의
- MemberRepository.java: 도메인 계층 인터페이스 정의
- JpaMemberRepository.java: Spring Data JPA 기반 기본 구현체
- QueryDslMemberRepository.java: QueryDSL 기반 커스텀 조회 구현체
  -  findByEmailAndDeletedFalse(String email) 메서드 구현

## ✅ 주요 체크 포인트

- [ ] 역할은 Spring Security 권한 체크에 맞게 ROLE_prefix 포함
- [ ] soft delete 전략(deleted = false) 적용 여부
- [ ] 이후 로그인 및 인가 처리 시 연동되는 구조인지 확인

## 🔁 테스트 결과

- 로그인 로직에서 Member 조회 정상 작동 확인
- query log에서 deleted = false 조건 확인됨

## 🔗 연관된 이슈

- #37 

<br>

## 📑 레퍼런스

- 없음
