### PR TITLE
[feat] 프로젝트 단계 일괄 수정 API 개발

### DIFF
--- a/src/main/java/kr/mywork/domain/project_step/model/ProjectStep.java
+++ b/src/main/java/kr/mywork/domain/project_step/model/ProjectStep.java
@@ -10,10 +10,12 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
 import kr.mywork.common.rdb.id.UnixTimeOrderedUuidGeneratedValue;
 import lombok.AccessLevel;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
 public class ProjectStep {
 
     @Id
@@ -32,5 +34,11 @@ public class ProjectStep {
     public ProjectStep(final String title, final Integer orderNum) {
         this.title = title;
         this.orderNum = orderNum;
+    }
+
+    public boolean update(final String title, final Integer orderNum) {
+        this.title = title;
+        this.orderNum = orderNum;
+        return true;
     }
 }

--- a/src/main/java/kr/mywork/domain/project_step/repository/ProjectStepRepository.java
+++ b/src/main/java/kr/mywork/domain/project_step/repository/ProjectStepRepository.java
@@ -1,9 +1,12 @@
 package kr.mywork.domain.project_step.repository;
 
 import java.util.List;
+import java.util.Set;
+import java.util.UUID;
 
 import kr.mywork.domain.project_step.model.ProjectStep;
 
 public interface ProjectStepRepository {
 	List<ProjectStep> saveAll(List<ProjectStep> projectSteps);
+	List<ProjectStep> findAllByIds(Set<UUID> projectStepIds);
 }

--- a/src/main/java/kr/mywork/domain/project_step/serivce/ProjectStepService.java
+++ b/src/main/java/kr/mywork/domain/project_step/serivce/ProjectStepService.java
@@ -1,17 +1,24 @@
 package kr.mywork.domain.project_step.serivce;
 
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import kr.mywork.domain.project_step.model.ProjectStep;
 import kr.mywork.domain.project_step.repository.ProjectStepRepository;
 import kr.mywork.domain.project_step.serivce.dto.request.ProjectStepCreateRequest;
+import kr.mywork.domain.project_step.serivce.dto.request.ProjectStepUpdateRequest;
+import kr.mywork.domain.project_step.serivce.dto.response.ProjectStepUpdateResponse;
 import lombok.RequiredArgsConstructor;
 
 @Service
 @RequiredArgsConstructor
+@Transactional
 public class ProjectStepService {
 
 	private final ProjectStepRepository projectStepRepository;
@@ -27,5 +34,32 @@ public class ProjectStepService {
 		final List<ProjectStep> savedProjectSteps = projectStepRepository.saveAll(projectSteps);
 
 		return savedProjectSteps.size();
+	}
+
+	public List<ProjectStepUpdateResponse> updateProjectSteps(
+		final UUID projectId, final List<ProjectStepUpdateRequest> projectStepUpdateRequests) {
+		// TODO ProjectId 검증 로직 추가
+
+		final Map<UUID, ProjectStepUpdateRequest> projectStepUpdateRequestMap =
+			transformProjectStepUpdateMap(projectStepUpdateRequests);
+
+		final Set<UUID> projectStepIds = projectStepUpdateRequestMap.keySet();
+		List<ProjectStep> projectSteps = projectStepRepository.findAllByIds(projectStepIds);
+
+		projectSteps.forEach(projectStep -> {
+			final ProjectStepUpdateRequest projectStepUpdateRequest =
+				projectStepUpdateRequestMap.get(projectStep.getId());
+
+			projectStep.update(projectStepUpdateRequest.title(), projectStepUpdateRequest.orderNum());
+		});
+
+		return projectSteps.stream().map(ProjectStepUpdateResponse::fromEntity).toList();
+	}
+
+	private Map<UUID, ProjectStepUpdateRequest> transformProjectStepUpdateMap(
+		final List<ProjectStepUpdateRequest> projectStepUpdateRequests) {
+		return projectStepUpdateRequests.stream().collect(
+			Collectors.toMap(ProjectStepUpdateRequest::projectStepId,
+				projectStepUpdateRequest -> projectStepUpdateRequest));
 	}
 }

--- a/src/main/java/kr/mywork/domain/project_step/serivce/dto/request/ProjectStepUpdateRequest.java
+++ b/src/main/java/kr/mywork/domain/project_step/serivce/dto/request/ProjectStepUpdateRequest.java
@@ -1,0 +1,6 @@
+package kr.mywork.domain.project_step.serivce.dto.request;
+
+import java.util.UUID;
+
+public record ProjectStepUpdateRequest(UUID projectStepId, String title, Integer orderNum) {
+}

--- a/src/main/java/kr/mywork/domain/project_step/serivce/dto/response/ProjectStepUpdateResponse.java
+++ b/src/main/java/kr/mywork/domain/project_step/serivce/dto/response/ProjectStepUpdateResponse.java
@@ -1,0 +1,11 @@
+package kr.mywork.domain.project_step.serivce.dto.response;
+
+import java.util.UUID;
+
+import kr.mywork.domain.project_step.model.ProjectStep;
+
+public record ProjectStepUpdateResponse(UUID projectStepId, String title, Integer orderNumber) {
+	public static ProjectStepUpdateResponse fromEntity(ProjectStep projectStep) {
+		return new ProjectStepUpdateResponse(projectStep.getId(), projectStep.getTitle(), projectStep.getOrderNum());
+	}
+}

--- a/src/main/java/kr/mywork/infrastructure/project_step/rdb/QueryDslProjectStepRepository.java
+++ b/src/main/java/kr/mywork/infrastructure/project_step/rdb/QueryDslProjectStepRepository.java
@@ -1,8 +1,14 @@
 package kr.mywork.infrastructure.project_step.rdb;
 
+import static kr.mywork.domain.project_step.model.QProjectStep.projectStep;
+
 import java.util.List;
+import java.util.Set;
+import java.util.UUID;
 
 import org.springframework.stereotype.Repository;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
 
 import kr.mywork.domain.project_step.model.ProjectStep;
 import kr.mywork.domain.project_step.repository.ProjectStepRepository;
@@ -13,9 +19,17 @@ import lombok.RequiredArgsConstructor;
 public class QueryDslProjectStepRepository implements ProjectStepRepository {
 
 	private final JpaProjectStepRepository jpaProjectStepRepository;
+	private final JPAQueryFactory queryFactory;
 
 	@Override
 	public List<ProjectStep> saveAll(final List<ProjectStep> projectSteps) {
 		return jpaProjectStepRepository.saveAll(projectSteps);
+	}
+
+	@Override
+	public List<ProjectStep> findAllByIds(final Set<UUID> projectStepIds) {
+		return queryFactory.selectFrom(projectStep)
+			.where(projectStep.id.in(projectStepIds))
+			.fetch();
 	}
 }

--- a/src/main/java/kr/mywork/interfaces/project_step/controller/ProjectStepController.java
+++ b/src/main/java/kr/mywork/interfaces/project_step/controller/ProjectStepController.java
@@ -4,7 +4,9 @@ import java.util.List;
 import java.util.UUID;
 
 import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -12,8 +14,13 @@ import jakarta.validation.Valid;
 import kr.mywork.common.api.support.response.ApiResponse;
 import kr.mywork.domain.project_step.serivce.ProjectStepService;
 import kr.mywork.domain.project_step.serivce.dto.request.ProjectStepCreateRequest;
+import kr.mywork.domain.project_step.serivce.dto.request.ProjectStepUpdateRequest;
+import kr.mywork.domain.project_step.serivce.dto.response.ProjectStepUpdateResponse;
 import kr.mywork.interfaces.project_step.dto.request.ProjectStepsCreateWebRequest;
+import kr.mywork.interfaces.project_step.dto.request.ProjectStepsUpdateWebRequest;
+import kr.mywork.interfaces.project_step.dto.response.ProjectStepUpdateWebResponse;
 import kr.mywork.interfaces.project_step.dto.response.ProjectStepsCreateWebResponse;
+import kr.mywork.interfaces.project_step.dto.response.ProjectStepsUpdateWebResponse;
 import lombok.RequiredArgsConstructor;
 
 @RestController
@@ -33,5 +40,20 @@ public class ProjectStepController {
 		final Integer createdCount = projectStepService.saveAll(projectId, serviceRequests);
 
 		return ApiResponse.success(new ProjectStepsCreateWebResponse(createdCount));
+	}
+
+	@PutMapping("/api/projects/{projectId}/steps")
+	public ApiResponse<ProjectStepsUpdateWebResponse> updateProjectSteps(
+		@PathVariable(name = "projectId") UUID projectId,
+		@RequestBody @Valid ProjectStepsUpdateWebRequest projectStepsUpdateWebRequest) {
+		final List<ProjectStepUpdateRequest> projectStepUpdateRequests = projectStepsUpdateWebRequest.toServiceRequests();
+
+		final List<ProjectStepUpdateResponse> projectStepUpdateResponses =
+			projectStepService.updateProjectSteps(projectId, projectStepUpdateRequests);
+
+		final List<ProjectStepUpdateWebResponse> projectStepUpdateWebResponses =
+			ProjectStepsUpdateWebResponse.fromServiceResponses(projectStepUpdateResponses);
+
+		return ApiResponse.success(new ProjectStepsUpdateWebResponse(projectStepUpdateWebResponses));
 	}
 }

--- a/src/main/java/kr/mywork/interfaces/project_step/dto/request/ProjectStepUpdateWebRequest.java
+++ b/src/main/java/kr/mywork/interfaces/project_step/dto/request/ProjectStepUpdateWebRequest.java
@@ -1,0 +1,30 @@
+package kr.mywork.interfaces.project_step.dto.request;
+
+import java.util.UUID;
+
+import org.hibernate.validator.constraints.Length;
+
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Positive;
+import kr.mywork.domain.project_step.serivce.dto.request.ProjectStepUpdateRequest;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@NoArgsConstructor(force = true)
+@RequiredArgsConstructor
+public class ProjectStepUpdateWebRequest {
+	private final UUID projectStepId;
+
+	@Length(min = 1, max = 30, message = "{project-step.invalid-title}")
+	private final String title;
+
+	@Positive(message = "{project-step.positive}")
+	@Max(value = Integer.MAX_VALUE, message = "{project-step.max-value}")
+	private final Integer orderNumber;
+
+	public ProjectStepUpdateRequest toServiceRequest() {
+		return new ProjectStepUpdateRequest(projectStepId, title, orderNumber);
+	}
+}

--- a/src/main/java/kr/mywork/interfaces/project_step/dto/request/ProjectStepsUpdateWebRequest.java
+++ b/src/main/java/kr/mywork/interfaces/project_step/dto/request/ProjectStepsUpdateWebRequest.java
@@ -1,0 +1,23 @@
+package kr.mywork.interfaces.project_step.dto.request;
+
+import java.util.List;
+
+import jakarta.validation.Valid;
+import kr.mywork.domain.project_step.serivce.dto.request.ProjectStepUpdateRequest;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@NoArgsConstructor(force = true)
+@RequiredArgsConstructor
+public class ProjectStepsUpdateWebRequest {
+	@Valid
+	private final List<ProjectStepUpdateWebRequest> projectStepUpdateWebRequests;
+
+	public List<ProjectStepUpdateRequest> toServiceRequests() {
+		return projectStepUpdateWebRequests.stream()
+			.map(ProjectStepUpdateWebRequest::toServiceRequest)
+			.toList();
+	}
+}

--- a/src/main/java/kr/mywork/interfaces/project_step/dto/response/ProjectStepUpdateWebResponse.java
+++ b/src/main/java/kr/mywork/interfaces/project_step/dto/response/ProjectStepUpdateWebResponse.java
@@ -1,0 +1,15 @@
+package kr.mywork.interfaces.project_step.dto.response;
+
+import java.util.UUID;
+
+import kr.mywork.domain.project_step.serivce.dto.response.ProjectStepUpdateResponse;
+
+public record ProjectStepUpdateWebResponse(UUID projectStepId, String title, Integer orderNumber) {
+
+	public static ProjectStepUpdateWebResponse fromServiceResponse(final ProjectStepUpdateResponse serviceResponse) {
+		return new ProjectStepUpdateWebResponse(
+			serviceResponse.projectStepId(),
+			serviceResponse.title(),
+			serviceResponse.orderNumber());
+	}
+}

--- a/src/main/java/kr/mywork/interfaces/project_step/dto/response/ProjectStepsUpdateWebResponse.java
+++ b/src/main/java/kr/mywork/interfaces/project_step/dto/response/ProjectStepsUpdateWebResponse.java
@@ -1,0 +1,17 @@
+package kr.mywork.interfaces.project_step.dto.response;
+
+import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import kr.mywork.domain.project_step.serivce.dto.response.ProjectStepUpdateResponse;
+
+public record ProjectStepsUpdateWebResponse (@JsonProperty("projectSteps") List<ProjectStepUpdateWebResponse> projectStepUpdateWebResponses) {
+
+	public static List<ProjectStepUpdateWebResponse> fromServiceResponses(
+		final List<ProjectStepUpdateResponse> projectStepUpdateWebResponses) {
+		return projectStepUpdateWebResponses.stream()
+			.map(ProjectStepUpdateWebResponse::fromServiceResponse)
+			.toList();
+	}
+}

--- a/src/test/java/kr/mywork/docs/ProjectStepDocumentationTest.java
+++ b/src/test/java/kr/mywork/docs/ProjectStepDocumentationTest.java
@@ -4,6 +4,7 @@ import static com.epages.restdocs.apispec.MockMvcRestDocumentationWrapper.docume
 import static com.epages.restdocs.apispec.ResourceDocumentation.headerWithName;
 import static com.epages.restdocs.apispec.ResourceDocumentation.resource;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.put;
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -16,6 +17,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.restdocs.payload.JsonFieldType;
+import org.springframework.test.context.jdbc.Sql;
 import org.springframework.test.web.servlet.ResultActions;
 
 import com.epages.restdocs.apispec.ResourceSnippet;
@@ -23,7 +25,9 @@ import com.epages.restdocs.apispec.ResourceSnippetParameters;
 
 import kr.mywork.common.api.support.response.ResultType;
 import kr.mywork.interfaces.project_step.dto.request.ProjectStepCreateWebRequest;
+import kr.mywork.interfaces.project_step.dto.request.ProjectStepUpdateWebRequest;
 import kr.mywork.interfaces.project_step.dto.request.ProjectStepsCreateWebRequest;
+import kr.mywork.interfaces.project_step.dto.request.ProjectStepsUpdateWebRequest;
 
 public class ProjectStepDocumentationTest extends RestDocsDocumentation {
 
@@ -62,14 +66,63 @@ public class ProjectStepDocumentationTest extends RestDocsDocumentation {
 	private ResourceSnippet projectIdCreateSuccessResource() {
 		return resource(
 			ResourceSnippetParameters.builder()
-				.tag("ProjectId API")
-				.summary("프로젝트 단계 API")
+				.tag("Project Step API")
+				.summary("프로젝트 단계 생성 API")
 				.description("프로젝트 단계를 생성한다")
 				.requestHeaders(
 					headerWithName(HttpHeaders.CONTENT_TYPE).description("컨텐츠 타입"))
 				.responseFields(
 					fieldWithPath("result").type(JsonFieldType.STRING).description("응답 결과"),
 					fieldWithPath("data.createdStepCount").type(JsonFieldType.NUMBER).description("생성한 프로젝트 단계 갯수"),
+					fieldWithPath("error").type(JsonFieldType.NULL).description("에러 정보"))
+				.build());
+	}
+
+	@Test
+	@DisplayName("프로젝트 단계 수정 성공")
+	@Sql("classpath:sql/project-step-update.sql")
+	void 프로젝트_단계_수정_성공() throws Exception {
+		// given
+		// TODO Project 생성 API 개발 후, ProjectId 생성 및 검증 샘플 데이터 추가 필요
+
+		final List<ProjectStepUpdateWebRequest> projectStepCreateWebRequests = List.of(
+			new ProjectStepUpdateWebRequest(UUID.fromString("01972ea5-0bc1-7b72-87d8-bdc93b2049c4"), "기획_수정", 1),
+			new ProjectStepUpdateWebRequest(UUID.fromString("01972ea5-3e04-7ced-b90e-9c5c4b83b733"), "개발_수정", 2),
+			new ProjectStepUpdateWebRequest(UUID.fromString("01972ea5-5554-757d-9c11-a1fe2587bfde"), "QA_수정", 3),
+			new ProjectStepUpdateWebRequest(UUID.fromString("01972ea5-73ff-75e1-9083-d1d51a0f186a"), "운영_수정", 4));
+
+		final ProjectStepsUpdateWebRequest projectStepsUpdateWebRequest =
+			new ProjectStepsUpdateWebRequest(projectStepCreateWebRequests);
+
+		final String requestBody = objectMapper.writeValueAsString(projectStepsUpdateWebRequest);
+
+		// when
+		final ResultActions result = mockMvc.perform(put("/api/projects/{projectId}/steps", "0197207e-7331-7000-946b-a29a79a82424")
+			.content(requestBody)
+			.contentType(MediaType.APPLICATION_JSON));
+
+		// then
+		result.andExpectAll(
+				status().isOk(),
+				jsonPath("$.result").value(ResultType.SUCCESS.name()),
+				jsonPath("$.data").exists(),
+				jsonPath("$.error").doesNotExist())
+			.andDo(document("project-id-update-success", projectIdUpdateSuccessResource()));
+	}
+
+	private ResourceSnippet projectIdUpdateSuccessResource() {
+		return resource(
+			ResourceSnippetParameters.builder()
+				.tag("Project Step API")
+				.summary("프로젝트 단계 일괄 수정 API")
+				.description("프로젝트 단계를 일괄 수정한다")
+				.requestHeaders(
+					headerWithName(HttpHeaders.CONTENT_TYPE).description("컨텐츠 타입"))
+				.responseFields(
+					fieldWithPath("result").type(JsonFieldType.STRING).description("응답 결과"),
+					fieldWithPath("data.projectSteps.[].projectStepId").type(JsonFieldType.STRING).description("프로젝트 단계 아이디"),
+					fieldWithPath("data.projectSteps.[].title").type(JsonFieldType.STRING).description("프로젝트 단계 이름"),
+					fieldWithPath("data.projectSteps.[].orderNumber").type(JsonFieldType.NUMBER).description("프로젝트 단계 순서"),
 					fieldWithPath("error").type(JsonFieldType.NULL).description("에러 정보"))
 				.build());
 	}

--- a/src/test/resources/sql/project-step-update.sql
+++ b/src/test/resources/sql/project-step-update.sql
@@ -1,0 +1,11 @@
+insert into project_step (order_num, created_at, id, title)
+values (1, '2025-06-02 11:00:00', UNHEX('01972ea50bc17b7287d8bdc93b2049c4'), '기획');
+
+insert into project_step (order_num, created_at, id, title)
+values (2, '2025-06-02 11:10:00', UNHEX('01972ea53e047cedb90e9c5c4b83b733'), '개발');
+
+insert into project_step (order_num, created_at, id, title)
+values (3, '2025-06-02 11:20:00', UNHEX('01972ea55554757d9c11a1fe2587bfde'), 'QA');
+
+insert into project_step (order_num, created_at, id, title)
+values (4, '2025-06-02 11:30:00', UNHEX('01972ea573ff75e19083d1d51a0f186a'), '운영');


### PR DESCRIPTION
## 📌 개요

- 프로젝트 단계 일괄 수정 API 개발

## 🛠️ 변경 사항

- 변경하고자 하는 프로젝트 단계의 Id, title, orderNumber 를 입력하면 해당 프로젝트가 수정됩니다.
- 변경하고자 하는 ProjectStep 을 조회하고 해당 데이터를 변경합니다.

## ✅ 주요 체크 포인트

- [ ] 수정하고자 하는 프로젝트가 단계가 정상 변경되는지 확인해야 합니다.

## 🔁 테스트 결과

![image](https://github.com/user-attachments/assets/7a45ea8b-d677-42fe-9c80-2a68e472b96e)

![image](https://github.com/user-attachments/assets/62ed6fdc-eeba-4c3e-9c57-862be3180054)

![image](https://github.com/user-attachments/assets/799fe545-d266-4895-be8d-756c435e8e65)

![image](https://github.com/user-attachments/assets/59212f2a-4e9f-4a9d-99cc-4411609a83b6)


## 🔗 연관된 이슈

- #43 
