### PR TITLE
[feat] 게시글 수정 API

### DIFF
--- a/src/main/java/kr/mywork/domain/post/errors/PostErrorCode.java
+++ b/src/main/java/kr/mywork/domain/post/errors/PostErrorCode.java
@@ -1,0 +1,6 @@
+package kr.mywork.domain.post.errors;
+
+public enum PostErrorCode {
+	ERROR_POST01,
+	ERROR_POST02
+}

--- a/src/main/java/kr/mywork/domain/post/errors/PostErrorType.java
+++ b/src/main/java/kr/mywork/domain/post/errors/PostErrorType.java
@@ -1,0 +1,14 @@
+package kr.mywork.domain.post.errors;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum PostErrorType {
+	ID_NOT_FOUND(PostErrorCode.ERROR_POST01, "게시글 아이디를 찾을 수 없습니다."),
+	POST_NOT_FOUND(PostErrorCode.ERROR_POST02, "게시글을 찾을 수 없습니다.");
+
+	private final PostErrorCode errorCode;
+	private final String message;
+}

--- a/src/main/java/kr/mywork/domain/post/errors/PostException.java
+++ b/src/main/java/kr/mywork/domain/post/errors/PostException.java
@@ -1,0 +1,13 @@
+package kr.mywork.domain.post.errors;
+
+import lombok.Getter;
+
+@Getter
+public abstract class PostException extends RuntimeException {
+	private final PostErrorType errorType;
+
+	public PostException(final PostErrorType errorType) {
+		super(errorType.getMessage());
+		this.errorType = errorType;
+	}
+}

--- a/src/main/java/kr/mywork/domain/post/errors/PostIdNotFoundException.java
+++ b/src/main/java/kr/mywork/domain/post/errors/PostIdNotFoundException.java
@@ -1,0 +1,7 @@
+package kr.mywork.domain.post.errors;
+
+public class PostIdNotFoundException extends PostException {
+    public PostIdNotFoundException(PostErrorType errorType) {
+		super(errorType);
+	}
+}

--- a/src/main/java/kr/mywork/domain/post/errors/PostNotFoundException.java
+++ b/src/main/java/kr/mywork/domain/post/errors/PostNotFoundException.java
@@ -1,0 +1,7 @@
+package kr.mywork.domain.post.errors;
+
+public class PostNotFoundException extends PostException {
+	public PostNotFoundException(PostErrorType errorType) {
+		super(errorType);
+	}
+}

--- a/src/main/java/kr/mywork/domain/post/model/Post.java
+++ b/src/main/java/kr/mywork/domain/post/model/Post.java
@@ -1,46 +1,60 @@
 package kr.mywork.domain.post.model;
 
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.Id;
 import java.time.LocalDateTime;
 import java.util.UUID;
-import kr.mywork.common.rdb.id.UnixTimeOrderedUuidGeneratedValue;
-import lombok.AccessLevel;
-import lombok.NoArgsConstructor;
+
 import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.annotations.UpdateTimestamp;
 
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
 public class Post {
 
-    @Id
-    @UnixTimeOrderedUuidGeneratedValue
-    private UUID id;
+	@Id
+	private UUID id;
 
-    private UUID projectStepId;
+	private UUID projectStepId;
 
-    @Column(length = 200)
-    private String title;
+	@Column(length = 200)
+	private String title;
 
-    @Column(length = 30)
-    private String companyName;
+	@Column(length = 30)
+	private String companyName;
 
-    @Column(length = 30)
-    private String authorName;
+	@Column(length = 30)
+	private String authorName;
 
-    @Column(length = 500)
-    private String content;
+	@Column(length = 500)
+	private String content;
 
-    @Column(length = 30)
-    private String approval;
+	@Column(length = 30)
+	private String approval;
 
-    private Boolean deleted;
+	private Boolean deleted;
 
-    @UpdateTimestamp
-    private LocalDateTime modifiedAt;
+	@UpdateTimestamp
+	private LocalDateTime modifiedAt;
 
-    @CreationTimestamp
-    private LocalDateTime createdAt;
+	@CreationTimestamp
+	private LocalDateTime createdAt;
+
+	public Post(final UUID id, final UUID projectStepId, final String title, final String companyName,
+		final String authorName, final String content, String approval, Boolean deleted) {
+		this.id = id;
+		this.projectStepId = projectStepId;
+		this.title = title;
+		this.companyName = companyName;
+		this.authorName = authorName;
+		this.content = content;
+		this.approval = approval;
+		this.deleted = deleted;
+	}
 }

--- a/src/main/java/kr/mywork/domain/post/model/Post.java
+++ b/src/main/java/kr/mywork/domain/post/model/Post.java
@@ -9,6 +9,7 @@ import org.hibernate.annotations.UpdateTimestamp;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
+import kr.mywork.domain.post.service.dto.request.PostUpdateRequest;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -56,5 +57,10 @@ public class Post {
 		this.content = content;
 		this.approval = approval;
 		this.deleted = deleted;
+	}
+
+	public void update(PostUpdateRequest postUpdateRequest) {
+		this.content = postUpdateRequest.getContent();
+		this.title = postUpdateRequest.getTitle();
 	}
 }

--- a/src/main/java/kr/mywork/domain/post/model/PostId.java
+++ b/src/main/java/kr/mywork/domain/post/model/PostId.java
@@ -1,0 +1,22 @@
+package kr.mywork.domain.post.model;
+
+import java.util.UUID;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class PostId {
+
+	@Id
+	@Getter
+	private UUID id;
+
+	public PostId(final UUID id) {
+		this.id = id;
+	}
+}

--- a/src/main/java/kr/mywork/domain/post/repository/PostIdRepository.java
+++ b/src/main/java/kr/mywork/domain/post/repository/PostIdRepository.java
@@ -1,0 +1,12 @@
+package kr.mywork.domain.post.repository;
+
+import java.util.Optional;
+import java.util.UUID;
+
+import kr.mywork.domain.post.model.PostId;
+
+public interface PostIdRepository {
+	UUID save(UUID postId);
+
+	Optional<PostId> findById(UUID id);
+}

--- a/src/main/java/kr/mywork/domain/post/repository/PostRepository.java
+++ b/src/main/java/kr/mywork/domain/post/repository/PostRepository.java
@@ -1,0 +1,8 @@
+package kr.mywork.domain.post.repository;
+
+import kr.mywork.domain.post.model.Post;
+import kr.mywork.domain.post.service.dto.request.PostCreateRequest;
+
+public interface PostRepository {
+	Post save(PostCreateRequest postCreateRequest);
+}

--- a/src/main/java/kr/mywork/domain/post/repository/PostRepository.java
+++ b/src/main/java/kr/mywork/domain/post/repository/PostRepository.java
@@ -1,8 +1,13 @@
 package kr.mywork.domain.post.repository;
 
+import java.util.Optional;
+import java.util.UUID;
+
 import kr.mywork.domain.post.model.Post;
 import kr.mywork.domain.post.service.dto.request.PostCreateRequest;
 
 public interface PostRepository {
 	Post save(PostCreateRequest postCreateRequest);
+
+	Optional<Post> findById(UUID id);
 }

--- a/src/main/java/kr/mywork/domain/post/service/PostService.java
+++ b/src/main/java/kr/mywork/domain/post/service/PostService.java
@@ -1,0 +1,40 @@
+package kr.mywork.domain.post.service;
+
+import java.util.UUID;
+
+import org.springframework.stereotype.Service;
+
+import com.fasterxml.uuid.Generators;
+
+import jakarta.transaction.Transactional;
+import kr.mywork.domain.post.errors.PostErrorType;
+import kr.mywork.domain.post.errors.PostIdNotFoundException;
+import kr.mywork.domain.post.model.Post;
+import kr.mywork.domain.post.repository.PostIdRepository;
+import kr.mywork.domain.post.repository.PostRepository;
+import kr.mywork.domain.post.service.dto.request.PostCreateRequest;
+import lombok.AccessLevel;
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor(access = AccessLevel.PROTECTED)
+public class PostService {
+
+	private final PostRepository postRepository;
+	private final PostIdRepository postIdRepository;
+
+	@Transactional
+	public UUID createPostId() {
+		final UUID postId = Generators.timeBasedEpochGenerator().generate();
+		return postIdRepository.save(postId);
+	}
+
+	@Transactional
+	public UUID createPost(PostCreateRequest postCreateRequest) {
+		postIdRepository.findById(postCreateRequest.getId())
+			.orElseThrow(() -> new PostIdNotFoundException(PostErrorType.ID_NOT_FOUND));
+
+		final Post savedPost = postRepository.save(postCreateRequest);
+		return savedPost.getId();
+	}
+}

--- a/src/main/java/kr/mywork/domain/post/service/PostService.java
+++ b/src/main/java/kr/mywork/domain/post/service/PostService.java
@@ -9,10 +9,13 @@ import com.fasterxml.uuid.Generators;
 import jakarta.transaction.Transactional;
 import kr.mywork.domain.post.errors.PostErrorType;
 import kr.mywork.domain.post.errors.PostIdNotFoundException;
+import kr.mywork.domain.post.errors.PostNotFoundException;
 import kr.mywork.domain.post.model.Post;
 import kr.mywork.domain.post.repository.PostIdRepository;
 import kr.mywork.domain.post.repository.PostRepository;
 import kr.mywork.domain.post.service.dto.request.PostCreateRequest;
+import kr.mywork.domain.post.service.dto.request.PostUpdateRequest;
+import kr.mywork.domain.post.service.dto.response.PostUpdateResponse;
 import lombok.AccessLevel;
 import lombok.RequiredArgsConstructor;
 
@@ -36,5 +39,14 @@ public class PostService {
 
 		final Post savedPost = postRepository.save(postCreateRequest);
 		return savedPost.getId();
+	}
+
+	@Transactional
+	public PostUpdateResponse updatePost(PostUpdateRequest postUpdateRequest) {
+		Post post = postRepository.findById(postUpdateRequest.getId())
+			.orElseThrow(() -> new PostNotFoundException(PostErrorType.POST_NOT_FOUND));
+
+		post.update(postUpdateRequest);
+		return PostUpdateResponse.from(post);
 	}
 }

--- a/src/main/java/kr/mywork/domain/post/service/dto/request/PostCreateRequest.java
+++ b/src/main/java/kr/mywork/domain/post/service/dto/request/PostCreateRequest.java
@@ -1,0 +1,34 @@
+package kr.mywork.domain.post.service.dto.request;
+
+import java.util.UUID;
+
+import kr.mywork.domain.post.model.Post;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class PostCreateRequest {
+
+	private final UUID id;
+
+	private final UUID projectStepId;
+
+	private final String title;
+
+	private final String companyName;
+
+	private final String authorName;
+
+	private final String content;
+
+	private final String approval;
+
+	private final Boolean deleted;
+
+	public Post toEntity() {
+		return new Post(this.getId(), this.getProjectStepId(), this.getTitle(),
+			this.getCompanyName(), this.getAuthorName(), this.getContent(),
+			this.getApproval(), this.getDeleted());
+	}
+}

--- a/src/main/java/kr/mywork/domain/post/service/dto/request/PostUpdateRequest.java
+++ b/src/main/java/kr/mywork/domain/post/service/dto/request/PostUpdateRequest.java
@@ -1,0 +1,18 @@
+package kr.mywork.domain.post.service.dto.request;
+
+import java.util.UUID;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class PostUpdateRequest {
+
+	private final UUID id;
+
+	private final String title;
+
+	private final String content;
+
+}

--- a/src/main/java/kr/mywork/domain/post/service/dto/response/PostCreateResponse.java
+++ b/src/main/java/kr/mywork/domain/post/service/dto/response/PostCreateResponse.java
@@ -1,0 +1,14 @@
+package kr.mywork.domain.post.service.dto.response;
+
+import java.time.LocalDateTime;
+
+import kr.mywork.domain.post.model.Post;
+
+public record PostCreateResponse(LocalDateTime createdAt, String authorName, String content, String approval) {
+
+	public static PostCreateResponse from(Post post) {
+		return new PostCreateResponse(post.getCreatedAt(), post.getAuthorName(), post.getContent(), post.getApproval());
+
+	}
+
+};

--- a/src/main/java/kr/mywork/domain/post/service/dto/response/PostUpdateResponse.java
+++ b/src/main/java/kr/mywork/domain/post/service/dto/response/PostUpdateResponse.java
@@ -1,0 +1,19 @@
+package kr.mywork.domain.post.service.dto.response;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+import kr.mywork.domain.post.model.Post;
+
+public record PostUpdateResponse(UUID id, UUID projectStepId, String title, String companyName, String authorName,
+								 String content, String approval, LocalDateTime createdAt) {
+
+	public static PostUpdateResponse from(Post post) {
+		return new PostUpdateResponse(
+			post.getId(), post.getProjectStepId(), post.getTitle(),
+			post.getCompanyName(), post.getAuthorName(), post.getContent(),
+			post.getApproval(), post.getCreatedAt()
+		);
+
+	}
+};

--- a/src/main/java/kr/mywork/domain/project_checklist/model/ProjectCheckList.java
+++ b/src/main/java/kr/mywork/domain/project_checklist/model/ProjectCheckList.java
@@ -1,4 +1,4 @@
-package kr.mywork.domain.projectCheckList.model;
+package kr.mywork.domain.project_checklist.model;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;

--- a/src/main/java/kr/mywork/domain/project_checklist/model/ProjectCheckListHistory.java
+++ b/src/main/java/kr/mywork/domain/project_checklist/model/ProjectCheckListHistory.java
@@ -1,4 +1,4 @@
-package kr.mywork.domain.projectCheckList.model;
+package kr.mywork.domain.project_checklist.model;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;

--- a/src/main/java/kr/mywork/domain/project_step/model/ProjectStep.java
+++ b/src/main/java/kr/mywork/domain/project_step/model/ProjectStep.java
@@ -16,21 +16,21 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class ProjectStep {
 
-    @Id
-    @UnixTimeOrderedUuidGeneratedValue
-    private UUID id;
+	@Id
+	@UnixTimeOrderedUuidGeneratedValue
+	private UUID id;
 
-    @Column(length = 30)
-    private String title;
+	@Column(length = 30)
+	private String title;
 
-    private Integer orderNum;
+	private Integer orderNum;
 
-    @CreationTimestamp
-    @Column(nullable = false)
-    private LocalDateTime createdAt;
+	@CreationTimestamp
+	@Column(nullable = false)
+	private LocalDateTime createdAt;
 
-    public ProjectStep(final String title, final Integer orderNum) {
-        this.title = title;
-        this.orderNum = orderNum;
-    }
+	public ProjectStep(final String title, final Integer orderNum) {
+		this.title = title;
+		this.orderNum = orderNum;
+	}
 }

--- a/src/main/java/kr/mywork/infrastructure/post/rdb/JpaPostIdRepository.java
+++ b/src/main/java/kr/mywork/infrastructure/post/rdb/JpaPostIdRepository.java
@@ -1,0 +1,10 @@
+package kr.mywork.infrastructure.post.rdb;
+
+import java.util.UUID;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import kr.mywork.domain.post.model.PostId;
+
+public interface JpaPostIdRepository extends JpaRepository<PostId, UUID> {
+}

--- a/src/main/java/kr/mywork/infrastructure/post/rdb/JpaPostRepository.java
+++ b/src/main/java/kr/mywork/infrastructure/post/rdb/JpaPostRepository.java
@@ -1,0 +1,10 @@
+package kr.mywork.infrastructure.post.rdb;
+
+import java.util.UUID;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import kr.mywork.domain.post.model.Post;
+
+public interface JpaPostRepository extends JpaRepository<Post, UUID> {
+}

--- a/src/main/java/kr/mywork/infrastructure/post/rdb/QueryDslPostIdRepository.java
+++ b/src/main/java/kr/mywork/infrastructure/post/rdb/QueryDslPostIdRepository.java
@@ -1,0 +1,38 @@
+package kr.mywork.infrastructure.post.rdb;
+
+import static kr.mywork.domain.post.model.QPostId.*;
+
+import java.util.Optional;
+import java.util.UUID;
+
+import org.springframework.stereotype.Repository;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+
+import kr.mywork.domain.post.model.PostId;
+import kr.mywork.domain.post.repository.PostIdRepository;
+import lombok.RequiredArgsConstructor;
+
+@Repository
+@RequiredArgsConstructor
+public class QueryDslPostIdRepository implements PostIdRepository {
+
+	private final JpaPostIdRepository jpaPostIdRepository;
+	private final JPAQueryFactory queryFactory;
+
+	@Override
+	public UUID save(final UUID postId) {
+		return jpaPostIdRepository.save(new PostId(postId)).getId();
+	}
+
+	@Override
+	public Optional<PostId> findById(final UUID id) {
+		final PostId findPostId = queryFactory.select(postId)
+			.from(postId)
+			.where(postId.id.eq(id))
+			.fetchFirst();
+
+		return Optional.ofNullable(findPostId);
+	}
+
+}

--- a/src/main/java/kr/mywork/infrastructure/post/rdb/QueryDslPostRepository.java
+++ b/src/main/java/kr/mywork/infrastructure/post/rdb/QueryDslPostRepository.java
@@ -1,5 +1,8 @@
 package kr.mywork.infrastructure.post.rdb;
 
+import java.util.Optional;
+import java.util.UUID;
+
 import org.springframework.stereotype.Repository;
 
 import kr.mywork.domain.post.model.Post;
@@ -16,6 +19,11 @@ public class QueryDslPostRepository implements PostRepository {
 	@Override
 	public Post save(final PostCreateRequest postCreateRequest) {
 		return postRepository.save(postCreateRequest.toEntity());
+	}
+
+	@Override
+	public Optional<Post> findById(final UUID id) {
+		return postRepository.findById(id);
 	}
 
 }

--- a/src/main/java/kr/mywork/infrastructure/post/rdb/QueryDslPostRepository.java
+++ b/src/main/java/kr/mywork/infrastructure/post/rdb/QueryDslPostRepository.java
@@ -1,0 +1,21 @@
+package kr.mywork.infrastructure.post.rdb;
+
+import org.springframework.stereotype.Repository;
+
+import kr.mywork.domain.post.model.Post;
+import kr.mywork.domain.post.repository.PostRepository;
+import kr.mywork.domain.post.service.dto.request.PostCreateRequest;
+import lombok.RequiredArgsConstructor;
+
+@Repository
+@RequiredArgsConstructor
+public class QueryDslPostRepository implements PostRepository {
+
+	private final JpaPostRepository postRepository;
+
+	@Override
+	public Post save(final PostCreateRequest postCreateRequest) {
+		return postRepository.save(postCreateRequest.toEntity());
+	}
+
+}

--- a/src/main/java/kr/mywork/interfaces/post/controller/PostController.java
+++ b/src/main/java/kr/mywork/interfaces/post/controller/PostController.java
@@ -8,6 +8,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import jakarta.validation.Valid;
 import kr.mywork.common.api.support.response.ApiResponse;
 import kr.mywork.domain.post.service.PostService;
 import kr.mywork.domain.post.service.dto.request.PostCreateRequest;
@@ -35,7 +36,7 @@ public class PostController {
 
 	@PostMapping
 	public ApiResponse<PostCreateWebResponse> createPost(
-		@RequestBody final PostCreateWebRequest postCreateWebRequest) {
+		@RequestBody @Valid final PostCreateWebRequest postCreateWebRequest) {
 
 		final PostCreateRequest postCreateRequest = postCreateWebRequest.toServiceDto();
 
@@ -49,7 +50,7 @@ public class PostController {
 
 	@PutMapping("")
 	public ApiResponse<PostUpdateWebResponse> updatePost(
-		@RequestBody final PostUpdateWebRequest postUpdateWebRequest) {
+		@RequestBody @Valid final PostUpdateWebRequest postUpdateWebRequest) {
 
 		final PostUpdateRequest postUpdateRequest = postUpdateWebRequest.toServiceDto();
 

--- a/src/main/java/kr/mywork/interfaces/post/controller/PostController.java
+++ b/src/main/java/kr/mywork/interfaces/post/controller/PostController.java
@@ -2,7 +2,6 @@ package kr.mywork.interfaces.post.controller;
 
 import java.util.UUID;
 
-import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -48,12 +47,11 @@ public class PostController {
 
 	}
 
-	@PutMapping("/{id}")
+	@PutMapping("")
 	public ApiResponse<PostUpdateWebResponse> updatePost(
-		@RequestBody final PostUpdateWebRequest postUpdateWebRequest,
-		@PathVariable final UUID id) {
+		@RequestBody final PostUpdateWebRequest postUpdateWebRequest) {
 
-		final PostUpdateRequest postUpdateRequest = postUpdateWebRequest.toServiceDto(id);
+		final PostUpdateRequest postUpdateRequest = postUpdateWebRequest.toServiceDto();
 
 		final PostUpdateResponse postUpdateResponse = postService.updatePost(postUpdateRequest);
 

--- a/src/main/java/kr/mywork/interfaces/post/controller/PostController.java
+++ b/src/main/java/kr/mywork/interfaces/post/controller/PostController.java
@@ -2,7 +2,9 @@ package kr.mywork.interfaces.post.controller;
 
 import java.util.UUID;
 
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -10,13 +12,17 @@ import org.springframework.web.bind.annotation.RestController;
 import kr.mywork.common.api.support.response.ApiResponse;
 import kr.mywork.domain.post.service.PostService;
 import kr.mywork.domain.post.service.dto.request.PostCreateRequest;
+import kr.mywork.domain.post.service.dto.request.PostUpdateRequest;
+import kr.mywork.domain.post.service.dto.response.PostUpdateResponse;
 import kr.mywork.interfaces.post.controller.dto.request.PostCreateWebRequest;
+import kr.mywork.interfaces.post.controller.dto.request.PostUpdateWebRequest;
 import kr.mywork.interfaces.post.controller.dto.response.PostCreateWebResponse;
 import kr.mywork.interfaces.post.controller.dto.response.PostIdCreateWebResponse;
+import kr.mywork.interfaces.post.controller.dto.response.PostUpdateWebResponse;
 import lombok.RequiredArgsConstructor;
 
 @RestController
-@RequestMapping("/api/post")
+@RequestMapping("/api/posts")
 @RequiredArgsConstructor
 public class PostController {
 
@@ -40,5 +46,19 @@ public class PostController {
 
 		return ApiResponse.success(postCreateWebResponse);
 
+	}
+
+	@PutMapping("/{id}")
+	public ApiResponse<PostUpdateWebResponse> updatePost(
+		@RequestBody final PostUpdateWebRequest postUpdateWebRequest,
+		@PathVariable final UUID id) {
+
+		final PostUpdateRequest postUpdateRequest = postUpdateWebRequest.toServiceDto(id);
+
+		final PostUpdateResponse postUpdateResponse = postService.updatePost(postUpdateRequest);
+
+		final PostUpdateWebResponse postUpdateWebResponse = PostUpdateWebResponse.from(postUpdateResponse);
+
+		return ApiResponse.success(postUpdateWebResponse);
 	}
 }

--- a/src/main/java/kr/mywork/interfaces/post/controller/PostController.java
+++ b/src/main/java/kr/mywork/interfaces/post/controller/PostController.java
@@ -1,0 +1,44 @@
+package kr.mywork.interfaces.post.controller;
+
+import java.util.UUID;
+
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import kr.mywork.common.api.support.response.ApiResponse;
+import kr.mywork.domain.post.service.PostService;
+import kr.mywork.domain.post.service.dto.request.PostCreateRequest;
+import kr.mywork.interfaces.post.controller.dto.request.PostCreateWebRequest;
+import kr.mywork.interfaces.post.controller.dto.response.PostCreateWebResponse;
+import kr.mywork.interfaces.post.controller.dto.response.PostIdCreateWebResponse;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("/api/post")
+@RequiredArgsConstructor
+public class PostController {
+
+	private final PostService postService;
+
+	@PostMapping("/id/generate")
+	public ApiResponse<PostIdCreateWebResponse> createPostId() {
+		final UUID postId = postService.createPostId();
+		return ApiResponse.success(new PostIdCreateWebResponse(postId));
+	}
+
+	@PostMapping
+	public ApiResponse<PostCreateWebResponse> createPost(
+		@RequestBody final PostCreateWebRequest postCreateWebRequest) {
+
+		final PostCreateRequest postCreateRequest = postCreateWebRequest.toServiceDto();
+
+		final UUID createdPostId = postService.createPost(postCreateRequest);
+
+		final PostCreateWebResponse postCreateWebResponse = new PostCreateWebResponse(createdPostId);
+
+		return ApiResponse.success(postCreateWebResponse);
+
+	}
+}

--- a/src/main/java/kr/mywork/interfaces/post/controller/dto/request/PostCreateWebRequest.java
+++ b/src/main/java/kr/mywork/interfaces/post/controller/dto/request/PostCreateWebRequest.java
@@ -2,6 +2,9 @@ package kr.mywork.interfaces.post.controller.dto.request;
 
 import java.util.UUID;
 
+import org.hibernate.validator.constraints.Length;
+
+import jakarta.validation.constraints.NotNull;
 import kr.mywork.domain.post.service.dto.request.PostCreateRequest;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
@@ -10,16 +13,24 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class PostCreateWebRequest {
 
+	@NotNull
 	private final UUID id;
 
+	@NotNull
 	private final UUID projectStepId;
 
+	@Length(min = 1, max = 200)
 	private final String title;
 
+	@NotNull
+	@Length(min = 1, max = 30)
 	private final String companyName;
 
+	@NotNull
+	@Length(min = 1, max = 30)
 	private final String authorName;
 
+	@Length(min = 1, max = 500)
 	private final String content;
 
 	public PostCreateRequest toServiceDto() {

--- a/src/main/java/kr/mywork/interfaces/post/controller/dto/request/PostCreateWebRequest.java
+++ b/src/main/java/kr/mywork/interfaces/post/controller/dto/request/PostCreateWebRequest.java
@@ -1,0 +1,30 @@
+package kr.mywork.interfaces.post.controller.dto.request;
+
+import java.util.UUID;
+
+import kr.mywork.domain.post.service.dto.request.PostCreateRequest;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class PostCreateWebRequest {
+
+	private final UUID id;
+
+	private final UUID projectStepId;
+
+	private final String title;
+
+	private final String companyName;
+
+	private final String authorName;
+
+	private final String content;
+
+	public PostCreateRequest toServiceDto() {
+		return new PostCreateRequest(this.id, this.projectStepId, this.title, this.companyName,
+			this.authorName, this.content, "PENDING", false);
+	}
+
+}

--- a/src/main/java/kr/mywork/interfaces/post/controller/dto/request/PostUpdateWebRequest.java
+++ b/src/main/java/kr/mywork/interfaces/post/controller/dto/request/PostUpdateWebRequest.java
@@ -2,6 +2,9 @@ package kr.mywork.interfaces.post.controller.dto.request;
 
 import java.util.UUID;
 
+import org.hibernate.validator.constraints.Length;
+
+import jakarta.validation.constraints.NotNull;
 import kr.mywork.domain.post.service.dto.request.PostUpdateRequest;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
@@ -10,10 +13,15 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class PostUpdateWebRequest {
 
+	@NotNull
 	private final UUID id;
 
+	@NotNull
+	@Length(min = 1, max = 200)
 	private final String title;
 
+	@NotNull
+	@Length(min = 1, max = 500)
 	private final String content;
 
 	public PostUpdateRequest toServiceDto() {

--- a/src/main/java/kr/mywork/interfaces/post/controller/dto/request/PostUpdateWebRequest.java
+++ b/src/main/java/kr/mywork/interfaces/post/controller/dto/request/PostUpdateWebRequest.java
@@ -2,7 +2,6 @@ package kr.mywork.interfaces.post.controller.dto.request;
 
 import java.util.UUID;
 
-import kr.mywork.domain.post.service.dto.request.PostCreateRequest;
 import kr.mywork.domain.post.service.dto.request.PostUpdateRequest;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
@@ -11,12 +10,14 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class PostUpdateWebRequest {
 
+	private final UUID id;
+
 	private final String title;
 
 	private final String content;
 
-	public PostUpdateRequest toServiceDto(UUID id) {
-		return new PostUpdateRequest(id, this.title, this.content);
+	public PostUpdateRequest toServiceDto() {
+		return new PostUpdateRequest(this.id, this.title, this.content);
 	}
 
 }

--- a/src/main/java/kr/mywork/interfaces/post/controller/dto/request/PostUpdateWebRequest.java
+++ b/src/main/java/kr/mywork/interfaces/post/controller/dto/request/PostUpdateWebRequest.java
@@ -1,0 +1,22 @@
+package kr.mywork.interfaces.post.controller.dto.request;
+
+import java.util.UUID;
+
+import kr.mywork.domain.post.service.dto.request.PostCreateRequest;
+import kr.mywork.domain.post.service.dto.request.PostUpdateRequest;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class PostUpdateWebRequest {
+
+	private final String title;
+
+	private final String content;
+
+	public PostUpdateRequest toServiceDto(UUID id) {
+		return new PostUpdateRequest(id, this.title, this.content);
+	}
+
+}

--- a/src/main/java/kr/mywork/interfaces/post/controller/dto/response/PostCreateWebResponse.java
+++ b/src/main/java/kr/mywork/interfaces/post/controller/dto/response/PostCreateWebResponse.java
@@ -1,0 +1,6 @@
+package kr.mywork.interfaces.post.controller.dto.response;
+
+import java.util.UUID;
+
+public record PostCreateWebResponse(UUID postId) {
+}

--- a/src/main/java/kr/mywork/interfaces/post/controller/dto/response/PostIdCreateWebResponse.java
+++ b/src/main/java/kr/mywork/interfaces/post/controller/dto/response/PostIdCreateWebResponse.java
@@ -1,0 +1,6 @@
+package kr.mywork.interfaces.post.controller.dto.response;
+
+import java.util.UUID;
+
+public record PostIdCreateWebResponse(UUID postId) {
+}

--- a/src/main/java/kr/mywork/interfaces/post/controller/dto/response/PostUpdateWebResponse.java
+++ b/src/main/java/kr/mywork/interfaces/post/controller/dto/response/PostUpdateWebResponse.java
@@ -4,10 +4,12 @@ import java.util.UUID;
 
 import kr.mywork.domain.post.service.dto.response.PostUpdateResponse;
 
-public record PostUpdateWebResponse(UUID postId, String title, String content) {
+public record PostUpdateWebResponse(UUID postId, String title, String content, String companyName, String authorName,
+									String approval) {
 
 	public static PostUpdateWebResponse from(PostUpdateResponse postUpdateResponse) {
 		return new PostUpdateWebResponse(postUpdateResponse.id(), postUpdateResponse.title(),
-			postUpdateResponse.content());
+			postUpdateResponse.content(), postUpdateResponse.companyName(), postUpdateResponse.authorName(),
+			postUpdateResponse.approval());
 	}
 }

--- a/src/main/java/kr/mywork/interfaces/post/controller/dto/response/PostUpdateWebResponse.java
+++ b/src/main/java/kr/mywork/interfaces/post/controller/dto/response/PostUpdateWebResponse.java
@@ -1,0 +1,13 @@
+package kr.mywork.interfaces.post.controller.dto.response;
+
+import java.util.UUID;
+
+import kr.mywork.domain.post.service.dto.response.PostUpdateResponse;
+
+public record PostUpdateWebResponse(UUID postId, String title, String content) {
+
+	public static PostUpdateWebResponse from(PostUpdateResponse postUpdateResponse) {
+		return new PostUpdateWebResponse(postUpdateResponse.id(), postUpdateResponse.title(),
+			postUpdateResponse.content());
+	}
+}

--- a/src/main/java/kr/mywork/interfaces/post/controller/errors/handler/PostControllerAdvice.java
+++ b/src/main/java/kr/mywork/interfaces/post/controller/errors/handler/PostControllerAdvice.java
@@ -1,0 +1,24 @@
+package kr.mywork.interfaces.post.controller.errors.handler;
+
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import kr.mywork.common.api.support.response.ApiResponse;
+import kr.mywork.domain.post.errors.PostErrorType;
+import kr.mywork.domain.post.errors.PostException;
+
+@Order(Ordered.LOWEST_PRECEDENCE - 1)
+@RestControllerAdvice
+public class PostControllerAdvice {
+
+	@ExceptionHandler(PostException.class)
+	public ResponseEntity<ApiResponse<?>> handlePostException(PostException exception) {
+		final PostErrorType errorType = exception.getErrorType();
+
+		return ResponseEntity.badRequest().body(
+			ApiResponse.error(errorType.getErrorCode().name(), errorType.getMessage()));
+	}
+}

--- a/src/test/java/kr/mywork/docs/PostDocumentationTest.java
+++ b/src/test/java/kr/mywork/docs/PostDocumentationTest.java
@@ -22,6 +22,7 @@ import com.fasterxml.uuid.Generators;
 
 import kr.mywork.common.api.support.response.ResultType;
 import kr.mywork.interfaces.post.controller.dto.request.PostCreateWebRequest;
+import kr.mywork.interfaces.post.controller.dto.request.PostUpdateWebRequest;
 
 public class PostDocumentationTest extends RestDocsDocumentation {
 
@@ -144,6 +145,54 @@ public class PostDocumentationTest extends RestDocsDocumentation {
 					fieldWithPath("error.code").type(JsonFieldType.STRING).description("에러 코드"),
 					fieldWithPath("error.message").type(JsonFieldType.STRING).description("에러 정보"),
 					fieldWithPath("error.data").type(JsonFieldType.NULL).description("에러 정보"))
+				.build()
+		);
+	}
+
+	@Test
+	@DisplayName("게시글 수정 성공")
+	@Sql("classpath:sql/post-for-update.sql")
+	void 게시글_수정_성공() throws Exception {
+		// given
+		UUID postId = UUID.fromString("1234a9a9-90b6-9898-a9dc-92c9861aa98c"); // UUID ver7
+
+		final PostUpdateWebRequest postUpdateWebRequest =
+			new PostUpdateWebRequest(postId, "바뀐 제목", "바뀐 컨텐츠");
+
+		final String requestBody = objectMapper.writeValueAsString(postUpdateWebRequest);
+
+		// when
+		final ResultActions result = mockMvc.perform(
+			put("/api/posts") // HTTP method (URL)
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(requestBody));
+
+		// then
+		result.andExpectAll(
+				status().isOk(),
+				jsonPath("$.result").value(ResultType.SUCCESS.name()),
+				jsonPath("$.data").exists(),
+				jsonPath("$.error").doesNotExist())
+			.andDo(document("post-update-success", postUpdateSuccessResource()));
+	}
+
+	private ResourceSnippet postUpdateSuccessResource() {
+		return resource(
+			ResourceSnippetParameters.builder()
+				.tag("Post API")
+				.summary("게시글 수정 API")
+				.description("게시글의 title, content를 수정한다.")
+				.requestHeaders(
+					headerWithName(HttpHeaders.CONTENT_TYPE).description("컨텐츠 타입"))
+				.responseFields(
+					fieldWithPath("result").type(JsonFieldType.STRING).description("응답 결과"),
+					fieldWithPath("data.postId").type(JsonFieldType.STRING).description("수정한 게시글 아이디"),
+					fieldWithPath("data.title").type(JsonFieldType.STRING).description("수정한 게시글 제목"),
+					fieldWithPath("data.content").type(JsonFieldType.STRING).description("수정한 게시글 내용"),
+					fieldWithPath("data.companyName").type(JsonFieldType.STRING).description("회사 이름"),
+					fieldWithPath("data.authorName").type(JsonFieldType.STRING).description("작성자"),
+					fieldWithPath("data.approval").type(JsonFieldType.STRING).description("승인여부"),
+					fieldWithPath("error").type(JsonFieldType.NULL).description("에러 정보"))
 				.build()
 		);
 	}

--- a/src/test/java/kr/mywork/docs/PostDocumentationTest.java
+++ b/src/test/java/kr/mywork/docs/PostDocumentationTest.java
@@ -1,0 +1,151 @@
+package kr.mywork.docs;
+
+import static com.epages.restdocs.apispec.MockMvcRestDocumentationWrapper.*;
+import static com.epages.restdocs.apispec.ResourceDocumentation.*;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.*;
+import static org.springframework.restdocs.payload.PayloadDocumentation.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import java.util.UUID;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.restdocs.payload.JsonFieldType;
+import org.springframework.test.context.jdbc.Sql;
+import org.springframework.test.web.servlet.ResultActions;
+
+import com.epages.restdocs.apispec.ResourceSnippet;
+import com.epages.restdocs.apispec.ResourceSnippetParameters;
+import com.fasterxml.uuid.Generators;
+
+import kr.mywork.common.api.support.response.ResultType;
+import kr.mywork.interfaces.post.controller.dto.request.PostCreateWebRequest;
+
+public class PostDocumentationTest extends RestDocsDocumentation {
+
+	@Test
+	@DisplayName("게시글 ID 생성 테스트")
+	void 게시글_아이디_생성_테스트_성공() throws Exception {
+
+		//given, when
+		ResultActions result = mockMvc.perform(
+			post("/api/post/id/generate")
+				.contentType(MediaType.APPLICATION_JSON));
+
+		//then
+		result.andExpectAll(
+			status().isOk(),
+			jsonPath("$.result").value(ResultType.SUCCESS.name()),
+			jsonPath("$.data").exists(),
+			jsonPath("$.error").doesNotExist()
+		).andDo(document("post-id-create-success", postIdCreateSuccessResource()));
+	}
+
+	private ResourceSnippet postIdCreateSuccessResource() {
+		return resource(
+			ResourceSnippetParameters.builder()
+				.tag("Post API")
+				.summary("게시글 아이디 API")
+				.description("게시글 아이디를 발급 받는다")
+				.requestHeaders(
+					headerWithName(HttpHeaders.CONTENT_TYPE).description("컨텐츠 타입"))
+				.responseFields(
+					fieldWithPath("result").type(JsonFieldType.STRING).description("응답 결과"),
+					fieldWithPath("data.postId").type(JsonFieldType.STRING).description("발급받은 게시글 생성 아이디"),
+					fieldWithPath("error").type(JsonFieldType.NULL).description("에러 정보"))
+				.build()
+		);
+	}
+
+	@Test
+	@DisplayName("게시글 생성 성공")
+	@Sql("classpath:sql/post-id.sql")
+	void 게시글_생성_성공() throws Exception {
+		// given
+		UUID postId = UUID.fromString("1234a9a9-90b6-9898-a9dc-92c9861aa98c"); // UUID ver7
+		UUID projectStepId = UUID.fromString("4321a2a2-00b2-0000-c2bb-81c0000aa00c"); // UUID ver7
+
+		final PostCreateWebRequest postCreateWebRequest =
+			new PostCreateWebRequest(postId, projectStepId, "게시글 제목", "게시글 이름", "저자 이름", "게시글 내용");
+
+		final String requestBody = objectMapper.writeValueAsString(postCreateWebRequest);
+
+		// when
+		final ResultActions result = mockMvc.perform(
+			post("/api/post") // HTTP method (URL)
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(requestBody));
+
+		// then
+		result.andExpectAll(
+				status().isOk(),
+				jsonPath("$.result").value(ResultType.SUCCESS.name()),
+				jsonPath("$.data").exists(),
+				jsonPath("$.error").doesNotExist())
+			.andDo(document("post-create-success", postCreateSuccessResource()));
+	}
+
+	private ResourceSnippet postCreateSuccessResource() {
+		return resource(
+			ResourceSnippetParameters.builder()
+				.tag("Post API")
+				.summary("게시글 생성 API")
+				.description("발급받은 게시글 아이디를 통해 게시글를 생성한다.")
+				.requestHeaders(
+					headerWithName(HttpHeaders.CONTENT_TYPE).description("컨텐츠 타입"))
+				.responseFields(
+					fieldWithPath("result").type(JsonFieldType.STRING).description("응답 결과"),
+					fieldWithPath("data.postId").type(JsonFieldType.STRING).description("생성한 게시글 아이디"),
+					fieldWithPath("error").type(JsonFieldType.NULL).description("에러 정보"))
+				.build()
+		);
+	}
+
+	@Test
+	@DisplayName("게시글 생성 실패 - 아이디가 존재하지 않는 경우")
+	void 게시글_생성_실패_아이디_미존재() throws Exception {
+		// given
+		UUID postId = Generators.timeBasedEpochGenerator().generate(); // UUID ver7
+		UUID projectStepId = UUID.fromString("4321a2a2-00b2-0000-c2bb-81c0000aa00c"); // UUID ver7
+
+		final PostCreateWebRequest postCreateWebRequest =
+			new PostCreateWebRequest(postId, projectStepId, "게시글 제목", "게시글 이름", "저자 이름", "게시글 내용");
+
+		final String requestBody = objectMapper.writeValueAsString(postCreateWebRequest);
+
+		// when
+		final ResultActions result = mockMvc.perform(
+			post("/api/post") // HTTP method (URL)
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(requestBody));
+
+		// then
+		result.andExpectAll(
+				status().is4xxClientError(),
+				jsonPath("$.result").value(ResultType.ERROR.name()),
+				jsonPath("$.data").doesNotExist(),
+				jsonPath("$.error").exists())
+			.andDo(document("post-create-fail01", postCreateFailResource01()));
+	}
+
+	private ResourceSnippet postCreateFailResource01() {
+		return resource(
+			ResourceSnippetParameters.builder()
+				.tag("Post API")
+				.summary("게시글 생성 API")
+				.description("발급받은 게시글 아이디를 통해 게시글를 생성한다.")
+				.requestHeaders(
+					headerWithName(HttpHeaders.CONTENT_TYPE).description("컨텐츠 타입"))
+				.responseFields(
+					fieldWithPath("result").type(JsonFieldType.STRING).description("응답 결과"),
+					fieldWithPath("data").type(JsonFieldType.NULL).description("응답 데이터"),
+					fieldWithPath("error.code").type(JsonFieldType.STRING).description("에러 코드"),
+					fieldWithPath("error.message").type(JsonFieldType.STRING).description("에러 정보"),
+					fieldWithPath("error.data").type(JsonFieldType.NULL).description("에러 정보"))
+				.build()
+		);
+	}
+
+}

--- a/src/test/java/kr/mywork/docs/PostDocumentationTest.java
+++ b/src/test/java/kr/mywork/docs/PostDocumentationTest.java
@@ -31,7 +31,7 @@ public class PostDocumentationTest extends RestDocsDocumentation {
 
 		//given, when
 		ResultActions result = mockMvc.perform(
-			post("/api/post/id/generate")
+			post("/api/posts/id/generate")
 				.contentType(MediaType.APPLICATION_JSON));
 
 		//then
@@ -74,7 +74,7 @@ public class PostDocumentationTest extends RestDocsDocumentation {
 
 		// when
 		final ResultActions result = mockMvc.perform(
-			post("/api/post") // HTTP method (URL)
+			post("/api/posts") // HTTP method (URL)
 				.contentType(MediaType.APPLICATION_JSON)
 				.content(requestBody));
 
@@ -117,7 +117,7 @@ public class PostDocumentationTest extends RestDocsDocumentation {
 
 		// when
 		final ResultActions result = mockMvc.perform(
-			post("/api/post") // HTTP method (URL)
+			post("/api/posts") // HTTP method (URL)
 				.contentType(MediaType.APPLICATION_JSON)
 				.content(requestBody));
 

--- a/src/test/resources/sql/post-for-update.sql
+++ b/src/test/resources/sql/post-for-update.sql
@@ -1,0 +1,25 @@
+INSERT INTO post_id
+VALUES (UNHEX(REPLACE('1234a9a9-90b6-9898-a9dc-92c9861aa98c', '-', '')));
+
+INSERT INTO post (id,
+                  project_step_id,
+                  title,
+                  company_name,
+                  author_name,
+                  content,
+                  approval,
+                  deleted,
+                  modified_at,
+                  created_at
+) VALUES (
+    UNHEX(REPLACE('1234a9a9-90b6-9898-a9dc-92c9861aa98c', '-', '')),
+    UNHEX(REPLACE('4321a2a2-00b2-0000-c2bb-81c0000aa00c', '-', '')),
+    '제목',
+    '회사명',
+    '작성자',
+    '내용',
+    '승인여부',
+    FALSE,
+    NOW(),
+    NOW()
+);

--- a/src/test/resources/sql/post-id.sql
+++ b/src/test/resources/sql/post-id.sql
@@ -1,0 +1,1 @@
+INSERT INTO post_id VALUES (UNHEX(REPLACE('1234a9a9-90b6-9898-a9dc-92c9861aa98c', '-', '')));


### PR DESCRIPTION
## 📌 개요
게시글 수정 API 를 구현합니다.

## 🛠️ 변경 사항
- 게시글 수정 API 추가

## ✅ 주요 체크 포인트
- [x] : DTO validate 처리
- [x] : 게시글 수정시 쿼리 결과
```zsh
Hibernate: select p1_0.id,p1_0.approval,p1_0.author_name,p1_0.company_name,p1_0.content,p1_0.created_at,p1_0.deleted,p1_0.modified_at,p1_0.project_step_id,p1_0.title from post p1_0 where p1_0.id=?
Hibernate: update post set approval=?,author_name=?,company_name=?,content=?,created_at=?,deleted=?,modified_at=?,project_step_id=?,title=? where id=?

```

## 🔁 테스트 결과
- 통합테스트 결과
요청 : 
![스크린샷 2025-06-02 오후 5 04 20](https://github.com/user-attachments/assets/58ce3af3-7422-4c6d-98b8-cc860b3a8b79)
응답 : 
![스크린샷 2025-06-02 오후 5 04 51](https://github.com/user-attachments/assets/b84e129b-5320-4638-8040-36f7672c518d)

## 🔗 연관된 이슈
- #47 
<br>