### PR TITLE
[build] PR 시 테스트 정상 동작 확인을 위한 action 도입

### DIFF
--- a/.github/workflows/pr-test-ci.yml
+++ b/.github/workflows/pr-test-ci.yml
@@ -1,0 +1,34 @@
+name: pr-test-ci.yml
+
+on:
+  pull_request:
+    branches:
+      - dev
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: (1) Set up Docker
+        uses: docker/setup-docker-action@v4
+      - name: (2) Checkout sources
+        uses: actions/checkout@v4
+      - name: (3) Setup Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: 17
+      - name: (4) Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+      - name: (5) Build with Gradle
+        run: ./gradlew clean test
+      - name: (6) 테스트 결과를 PR 코멘트로 출력
+        uses: EnricoMi/publish-unit-test-result-action@v2
+        if: always()
+        with:
+          files: '**/build/test-results/test/TEST-*.xml'
+
+      - name: (7) 테스트 실패 시, 오류가 발생한 코드 라인에 코멘트 추가
+        uses: mikepenz/action-junit-report@v4
+        if: always()
+        with:
+          report_paths: '**/build/test-results/test/TEST-*.xml'


### PR DESCRIPTION
## 📌 개요

- PR 에서 테스트 실행을 위한 action 도입

## 🛠️ 변경 사항

1. PR 실패 시 CI/CD github action workflow 가 동작하지 않는 문제 발생으로 지속적 통합이 안돼는 문제 발생
2. 테스트 실패로 인한 빌드 실패 방지를 위한 action 도입
   - `EnricoMi/publish-unit-test-result-action@v2` : 테스트 결과를 PR 코멘트로 출력
   - `mikepenz/action-junit-report@v4` : 테스트 실패 시, 오류가 발생한 코드 라인에 코멘트 추가

## ✅ 주요 체크 포인트


## 🔁 테스트 결과

- 자동화를 통한 테스트 정상 동작 확인 가능

## 🔗 연관된 이슈

- #60 

<br>

## 📑 레퍼런스

- https://github.com/EnricoMi/publish-unit-test-result-action
- https://github.com/mikepenz/action-junit-report