### PR TITLE
[feat] Spring Security 인증/인가 로직 구현 (#30)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -67,6 +67,13 @@ dependencies {
     testImplementation("org.springframework.boot:spring-boot-testcontainers")
     testImplementation("org.testcontainers:junit-jupiter")
     testImplementation("org.testcontainers:mysql")
+
+    // Spring Security + JWT 인증/인가 설정
+    implementation 'org.springframework.boot:spring-boot-starter-security'
+    implementation 'io.jsonwebtoken:jjwt-api:0.12.6'
+    runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.6'
+    runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.6'
+    testImplementation 'org.springframework.security:spring-security-test'
 }
 
 openapi3 {

--- a/src/main/java/kr/mywork/common/api/components/handler/GlobalExceptionHandler.java
+++ b/src/main/java/kr/mywork/common/api/components/handler/GlobalExceptionHandler.java
@@ -4,12 +4,16 @@ import java.util.Arrays;
 import java.util.List;
 
 import org.springframework.core.annotation.Order;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
 import kr.mywork.common.api.support.error.CommonErrorType;
 import kr.mywork.common.api.support.response.ApiResponse;
+import kr.mywork.domain.auth.errors.AuthErrorType;
+import kr.mywork.domain.auth.errors.AuthException;
+import kr.mywork.interfaces.auth.exception.CommonAuthenticationException;
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
@@ -37,6 +41,32 @@ public class GlobalExceptionHandler {
 		logWarn(exception);
 
 		return ResponseEntity.internalServerError()
+			.body(ApiResponse.error(errorType.getErrorCode().name(), errorType.getMessage()));
+	}
+
+	@ExceptionHandler(CommonAuthenticationException.class)
+	public ResponseEntity<ApiResponse<?>> handleCommonAuthenticationException(CommonAuthenticationException exception) {
+		final CommonErrorType errorType = exception.getErrorType();
+
+		log.warn("authentication error: {}, message: {}\n stackTrace: {}",
+			exception.getClass().getSimpleName(),
+			errorType.getMessage(),
+			String.join("\n", getStackTraces(exception)));
+
+		return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+			.body(ApiResponse.error(errorType.getErrorCode().name(), errorType.getMessage()));
+	}
+
+	@ExceptionHandler(AuthException.class)
+	public ResponseEntity<ApiResponse<?>> handleAuthException(AuthException exception) {
+		final AuthErrorType errorType = exception.getErrorType();
+
+		log.warn("auth error: {}, message: {}\n stackTrace: {}",
+			exception.getClass().getSimpleName(),
+			errorType.getMessage(),
+			String.join("\n", getStackTraces(exception)));
+
+		return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
 			.body(ApiResponse.error(errorType.getErrorCode().name(), errorType.getMessage()));
 	}
 

--- a/src/main/java/kr/mywork/common/api/support/error/CommonErrorCode.java
+++ b/src/main/java/kr/mywork/common/api/support/error/CommonErrorCode.java
@@ -2,6 +2,10 @@ package kr.mywork.common.api.support.error;
 
 public enum CommonErrorCode {
 	ERROR_COMMON01,
-	ERROR_COMMON02
+	ERROR_COMMON02,
+	ERROR_COMMON03,
+	ERROR_COMMON04,
+	ERROR_COMMON05,
+	ERROR_COMMON06;
 	;
 }

--- a/src/main/java/kr/mywork/common/api/support/error/CommonErrorType.java
+++ b/src/main/java/kr/mywork/common/api/support/error/CommonErrorType.java
@@ -7,8 +7,11 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum CommonErrorType {
 	ERROR_UNKNOWN(CommonErrorCode.ERROR_COMMON01, "알 수 없는 예외가 발생했습니다."),
-	INVALID_REQUEST_ARGUMENT(CommonErrorCode.ERROR_COMMON02, "유효하지 않는 입력 값을 포함하고 있습니다.");
-
+	INVALID_REQUEST_ARGUMENT(CommonErrorCode.ERROR_COMMON02, "유효하지 않는 입력 값을 포함하고 있습니다."),
+	UNAUTHORIZED(CommonErrorCode.ERROR_COMMON03, "인증이 필요하거나 로그인 정보가 올바르지 않습니다."),
+	INVALID_CONTENT_TYPE(CommonErrorCode.ERROR_COMMON04, "요청의 Content-Type이 application/json이 아닙니다."),
+	INVALID_INPUT_VALUE(CommonErrorCode.ERROR_COMMON05, "이메일 또는 비밀번호가 비어 있습니다."),
+	INVALID_JSON_INPUT(CommonErrorCode.ERROR_COMMON06, "요청의 JSON 파싱에 실패했습니다.");
 	private final CommonErrorCode errorCode;
 	private final String message;
 }

--- a/src/main/java/kr/mywork/common/auth/JwtProperties.java
+++ b/src/main/java/kr/mywork/common/auth/JwtProperties.java
@@ -1,0 +1,29 @@
+package kr.mywork.common.auth;
+
+import lombok.Getter;
+import lombok.Setter;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@Getter
+@Setter
+@ConfigurationProperties(prefix = "jwt")
+public class JwtProperties {
+
+	private AccessToken accessToken = new AccessToken();
+	private RefreshToken refreshToken = new RefreshToken();
+
+	@Getter
+	@Setter
+	public static class AccessToken {
+		private String privateKey;
+		private long expiration;
+	}
+
+	@Getter
+	@Setter
+	public static class RefreshToken {
+		private String privateKey;
+		private long expiration;
+	}
+}

--- a/src/main/java/kr/mywork/common/auth/config/AuthenticationProviderConfig.java
+++ b/src/main/java/kr/mywork/common/auth/config/AuthenticationProviderConfig.java
@@ -1,0 +1,28 @@
+package kr.mywork.common.auth.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.authentication.AuthenticationProvider;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+import kr.mywork.domain.auth.service.JwtAuthenticationProvider;
+import kr.mywork.domain.auth.service.MemberDetailService;
+import lombok.RequiredArgsConstructor;
+
+@Configuration
+@RequiredArgsConstructor
+public class AuthenticationProviderConfig {
+
+	private final MemberDetailService memberDetailService;
+
+	@Bean
+	public PasswordEncoder passwordEncoder() {
+		return new BCryptPasswordEncoder();
+	}
+
+	@Bean
+	public AuthenticationProvider loginAuthenticationProvider() {
+		return new JwtAuthenticationProvider(memberDetailService, passwordEncoder());
+	}
+}

--- a/src/main/java/kr/mywork/domain/auth/dto/LoginSuccessAuthenticationToken.java
+++ b/src/main/java/kr/mywork/domain/auth/dto/LoginSuccessAuthenticationToken.java
@@ -1,0 +1,38 @@
+package kr.mywork.domain.auth.dto;
+
+import java.util.Collection;
+
+import org.springframework.security.authentication.AbstractAuthenticationToken;
+import org.springframework.security.core.GrantedAuthority;
+
+public class LoginSuccessAuthenticationToken extends AbstractAuthenticationToken {
+
+	private final Object principal;
+	private final Object credentials;
+
+	private LoginSuccessAuthenticationToken(
+		final Object principal, Collection<? extends GrantedAuthority> authorities, Object credentials) {
+		super(authorities);
+		this.principal = principal;
+		this.credentials = credentials;
+		setAuthenticated(true);
+	}
+
+
+	public static LoginSuccessAuthenticationToken create(
+		Object principal,
+		Collection<? extends GrantedAuthority> authorities
+	) {
+		return new LoginSuccessAuthenticationToken(principal, null, authorities);
+	}
+
+	@Override
+	public Object getPrincipal() {
+		return principal;
+	}
+
+	@Override
+	public Object getCredentials() {
+		return credentials;
+	}
+}

--- a/src/main/java/kr/mywork/domain/auth/dto/LoginTrialAuthenticationToken.java
+++ b/src/main/java/kr/mywork/domain/auth/dto/LoginTrialAuthenticationToken.java
@@ -1,0 +1,42 @@
+package kr.mywork.domain.auth.dto;
+
+import org.springframework.security.authentication.AbstractAuthenticationToken;
+import org.springframework.security.core.GrantedAuthority;
+
+import java.util.Collection;
+
+public class LoginTrialAuthenticationToken extends AbstractAuthenticationToken {
+
+	private final Object principal;
+	private final Object credentials;
+
+	public LoginTrialAuthenticationToken(Object principal, Object credentials) {
+		super(null);
+		this.principal = principal;
+		this.credentials = credentials;
+		setAuthenticated(false);
+	}
+
+	public LoginTrialAuthenticationToken(Object principal, Object credentials,
+		Collection<? extends GrantedAuthority> authorities) {
+		super(authorities);
+		this.principal = principal;
+		this.credentials = credentials;
+		setAuthenticated(true);
+	}
+
+	public static LoginTrialAuthenticationToken create(final Object principal, final Object credentials) {
+		return new LoginTrialAuthenticationToken(principal, credentials);
+	}
+
+	@Override
+	public Object getPrincipal() {
+		return this.principal;
+	}
+
+	@Override
+	public Object getCredentials() {
+		return this.credentials;
+	}
+
+}

--- a/src/main/java/kr/mywork/domain/auth/dto/MemberDetails.java
+++ b/src/main/java/kr/mywork/domain/auth/dto/MemberDetails.java
@@ -1,0 +1,39 @@
+package kr.mywork.domain.auth.dto;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.UUID;
+
+@Getter
+@RequiredArgsConstructor
+public class MemberDetails implements UserDetails {
+
+    private final UUID id;
+    private final String email;
+    private final String password;
+    private final GrantedAuthority authority;
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return List.of(authority); // 하나만 감싸서 전달
+    }
+
+    @Override
+    public String getUsername() {
+        return this.email;
+    }
+
+    @Override
+    public String getPassword() {
+        return this.password;
+    }
+
+    public String getAuthorityAsStr() {
+        return this.authority.getAuthority();
+    }
+}

--- a/src/main/java/kr/mywork/domain/auth/dto/response/TokenResponse.java
+++ b/src/main/java/kr/mywork/domain/auth/dto/response/TokenResponse.java
@@ -1,0 +1,13 @@
+package kr.mywork.domain.auth.dto.response;
+
+import java.time.LocalDateTime;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class TokenResponse {
+	private final String accessToken;
+	private final LocalDateTime expiresAt;
+}

--- a/src/main/java/kr/mywork/domain/auth/errors/AuthErrorCode.java
+++ b/src/main/java/kr/mywork/domain/auth/errors/AuthErrorCode.java
@@ -1,0 +1,10 @@
+package kr.mywork.domain.auth.errors;
+
+public enum AuthErrorCode {
+	ERROR_AUTH01, // 유효하지 않은 토큰
+	ERROR_AUTH02, // 만료된 토큰
+	ERROR_AUTH03, // Refresh Token 없음
+	ERROR_AUTH04, // 인증 실패
+	ERROR_AUTH05, // 접근 권한 없음
+	ERROR_AUTH06;
+}

--- a/src/main/java/kr/mywork/domain/auth/errors/AuthErrorType.java
+++ b/src/main/java/kr/mywork/domain/auth/errors/AuthErrorType.java
@@ -1,0 +1,18 @@
+package kr.mywork.domain.auth.errors;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum AuthErrorType {
+	INVALID_TOKEN(AuthErrorCode.ERROR_AUTH01, "유효하지 않은 토큰입니다."),
+	EXPIRED_TOKEN(AuthErrorCode.ERROR_AUTH02, "만료된 토큰입니다."),
+	REFRESH_TOKEN_NOT_FOUND(AuthErrorCode.ERROR_AUTH03, "Refresh Token이 존재하지 않습니다."),
+	AUTHENTICATION_FAILED(AuthErrorCode.ERROR_AUTH04, "인증에 실패했습니다."),
+	ACCESS_DENIED(AuthErrorCode.ERROR_AUTH05, "접근 권한이 없습니다."),
+	INVALID_LOGIN(AuthErrorCode.ERROR_AUTH06, "이메일 또는 비밀번호가 올바르지 않습니다.");
+
+	private final AuthErrorCode errorCode;
+	private final String message;
+}

--- a/src/main/java/kr/mywork/domain/auth/errors/AuthException.java
+++ b/src/main/java/kr/mywork/domain/auth/errors/AuthException.java
@@ -1,0 +1,13 @@
+package kr.mywork.domain.auth.errors;
+
+import lombok.Getter;
+
+@Getter
+public class AuthException extends RuntimeException {
+	private final AuthErrorType errorType;
+
+	public AuthException(AuthErrorType errorType) {
+		super(errorType.getMessage());
+		this.errorType = errorType;
+	}
+}

--- a/src/main/java/kr/mywork/domain/auth/errors/AuthenticationFailedException.java
+++ b/src/main/java/kr/mywork/domain/auth/errors/AuthenticationFailedException.java
@@ -1,0 +1,7 @@
+package kr.mywork.domain.auth.errors;
+
+public class AuthenticationFailedException extends AuthException {
+	public AuthenticationFailedException(AuthErrorType errorType) {
+		super(errorType);
+	}
+}

--- a/src/main/java/kr/mywork/domain/auth/errors/InvalidTokenException.java
+++ b/src/main/java/kr/mywork/domain/auth/errors/InvalidTokenException.java
@@ -1,0 +1,7 @@
+package kr.mywork.domain.auth.errors;
+
+public class InvalidTokenException extends AuthException {
+	public InvalidTokenException(AuthErrorType errorType) {
+		super(errorType);
+	}
+}

--- a/src/main/java/kr/mywork/domain/auth/errors/JwtAccessDeniedException.java
+++ b/src/main/java/kr/mywork/domain/auth/errors/JwtAccessDeniedException.java
@@ -1,0 +1,7 @@
+package kr.mywork.domain.auth.errors;
+
+public class JwtAccessDeniedException extends AuthException {
+	public JwtAccessDeniedException(AuthErrorType errorType) {
+		super(errorType);
+	}
+}

--- a/src/main/java/kr/mywork/domain/auth/errors/RefreshTokenNotFoundException.java
+++ b/src/main/java/kr/mywork/domain/auth/errors/RefreshTokenNotFoundException.java
@@ -1,0 +1,7 @@
+package kr.mywork.domain.auth.errors;
+
+public class RefreshTokenNotFoundException extends AuthException {
+	public RefreshTokenNotFoundException(AuthErrorType errorType) {
+		super(errorType);
+	}
+}

--- a/src/main/java/kr/mywork/domain/auth/model/BlacklistedRefreshToken.java
+++ b/src/main/java/kr/mywork/domain/auth/model/BlacklistedRefreshToken.java
@@ -1,0 +1,40 @@
+package kr.mywork.domain.auth.model;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import kr.mywork.common.rdb.id.UnixTimeOrderedUuidGeneratedValue;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.CreationTimestamp;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class BlacklistedRefreshToken {
+
+	@Id
+	@UnixTimeOrderedUuidGeneratedValue
+	private UUID id;
+
+	@Column(nullable = false, columnDefinition = "TEXT")
+	private String token;
+
+	@Column(nullable = false)
+	private LocalDateTime expiresAt;
+
+	@CreationTimestamp
+	private LocalDateTime createdAt;
+
+	@Builder
+	public BlacklistedRefreshToken(String token, LocalDateTime expiresAt) {
+		this.token = token;
+		this.expiresAt = expiresAt;
+	}
+}

--- a/src/main/java/kr/mywork/domain/auth/repository/BlacklistedRefreshTokenRepository.java
+++ b/src/main/java/kr/mywork/domain/auth/repository/BlacklistedRefreshTokenRepository.java
@@ -1,0 +1,15 @@
+package kr.mywork.domain.auth.repository;
+
+import java.util.Optional;
+
+import kr.mywork.domain.auth.model.BlacklistedRefreshToken;
+
+public interface BlacklistedRefreshTokenRepository {
+	BlacklistedRefreshToken save(BlacklistedRefreshToken token);
+
+	Optional<BlacklistedRefreshToken> findByToken(String token);
+
+	boolean existsByToken(String token);
+
+	void deleteExpiredTokens();
+}

--- a/src/main/java/kr/mywork/domain/auth/scheduler/DeleteExpiredTokenScheduler.java
+++ b/src/main/java/kr/mywork/domain/auth/scheduler/DeleteExpiredTokenScheduler.java
@@ -1,0 +1,18 @@
+package kr.mywork.domain.auth.scheduler;
+
+import kr.mywork.domain.auth.repository.BlacklistedRefreshTokenRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class DeleteExpiredTokenScheduler {
+
+	private final BlacklistedRefreshTokenRepository blacklistedRefreshTokenRepository;
+
+	@Scheduled(cron = "0 0 3 * * *")
+	public void cleanUpExpiredTokens() {
+		blacklistedRefreshTokenRepository.deleteExpiredTokens();
+	}
+}

--- a/src/main/java/kr/mywork/domain/auth/service/JwtAuthenticationProvider.java
+++ b/src/main/java/kr/mywork/domain/auth/service/JwtAuthenticationProvider.java
@@ -1,0 +1,46 @@
+package kr.mywork.domain.auth.service;
+
+import org.springframework.security.authentication.AuthenticationProvider;
+import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+import kr.mywork.domain.auth.dto.MemberDetails;
+import kr.mywork.domain.auth.dto.LoginSuccessAuthenticationToken;
+import kr.mywork.domain.auth.dto.LoginTrialAuthenticationToken;
+import kr.mywork.domain.auth.errors.AuthErrorType;
+import kr.mywork.domain.auth.errors.AuthException;
+
+public class JwtAuthenticationProvider implements AuthenticationProvider {
+
+	private final MemberDetailService memberDetailService;
+	private final PasswordEncoder passwordEncoder;
+
+	public JwtAuthenticationProvider(MemberDetailService memberDetailService, PasswordEncoder passwordEncoder) {
+		this.memberDetailService = memberDetailService;
+		this.passwordEncoder = passwordEncoder;
+	}
+
+	@Override
+	public Authentication authenticate(Authentication authentication) throws AuthenticationException {
+		LoginTrialAuthenticationToken authToken = (LoginTrialAuthenticationToken) authentication;
+
+		String email = authToken.getPrincipal().toString();
+		String rawPassword = authToken.getCredentials().toString();
+
+		MemberDetails memberDetails = memberDetailService.loadUserByUsername(email);
+
+		if (!passwordEncoder.matches(rawPassword, memberDetails.getPassword())) {
+			throw new AuthException(AuthErrorType.AUTHENTICATION_FAILED);
+		}
+
+
+		return LoginSuccessAuthenticationToken.create(memberDetails, memberDetails.getAuthorities());
+	}
+
+	@Override
+	public boolean supports(Class<?> authentication) {
+		return LoginTrialAuthenticationToken.class.isAssignableFrom(authentication);
+	}
+}

--- a/src/main/java/kr/mywork/domain/auth/service/JwtTokenProvider.java
+++ b/src/main/java/kr/mywork/domain/auth/service/JwtTokenProvider.java
@@ -1,0 +1,159 @@
+package kr.mywork.domain.auth.service;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.JwtException;
+import io.jsonwebtoken.JwtParser;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import kr.mywork.common.auth.JwtProperties;
+import kr.mywork.domain.auth.errors.AuthErrorType;
+import kr.mywork.domain.auth.errors.AuthException;
+
+import javax.crypto.SecretKey;
+import java.nio.charset.StandardCharsets;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+
+public class JwtTokenProvider {
+
+	private final SecretKey accessTokenPrivateKey;
+	private final SecretKey refreshTokenPrivateKey;
+	private final Long accessTokenExpirationMillis;
+	private final Long refreshTokenExpirationMillis;
+
+	private final JwtParser accessTokenParser;
+	private final JwtParser refreshTokenParser;
+
+	public JwtTokenProvider(JwtProperties jwtProperties) {
+		this.accessTokenPrivateKey = transformSecretKey(jwtProperties.getAccessToken().getPrivateKey());
+		this.refreshTokenPrivateKey = transformSecretKey(jwtProperties.getRefreshToken().getPrivateKey());
+		this.accessTokenExpirationMillis = jwtProperties.getAccessToken().getExpiration();
+		this.refreshTokenExpirationMillis = jwtProperties.getRefreshToken().getExpiration();
+		this.accessTokenParser = createJwtParser(this.accessTokenPrivateKey);
+		this.refreshTokenParser = createJwtParser(this.refreshTokenPrivateKey);
+	}
+
+	public long getRefreshTokenExpirationMillis() {
+		return refreshTokenExpirationMillis;
+	}
+
+	private JwtParser createJwtParser(final SecretKey secretKey) {
+		return Jwts.parser()
+			.verifyWith(secretKey)
+			.build();
+	}
+
+	private SecretKey transformSecretKey(final String secretKey) {
+		return Keys.hmacShaKeyFor(secretKey.getBytes(StandardCharsets.UTF_8));
+	}
+
+	public String createAccessToken(final UUID memberId, final String email, final String role) {
+		final Date now = new Date();
+		final Date expiry = new Date(now.getTime() + accessTokenExpirationMillis);
+
+		Map<String, Object> claims = new HashMap<>();
+		claims.put("memberId", memberId);
+		claims.put("email", email);
+		claims.put("role", role);
+
+		return Jwts.builder()
+			.subject(String.valueOf(memberId))
+			.claims(claims)
+			.issuedAt(now)
+			.expiration(expiry)
+			.signWith(accessTokenPrivateKey)
+			.compact();
+	}
+
+	public String createRefreshToken(final UUID memberId, final String email, final String role) {
+		final Date now = new Date();
+		final Date expiry = new Date(now.getTime() + refreshTokenExpirationMillis);
+
+		Map<String, Object> claims = new HashMap<>();
+		claims.put("memberId", memberId);
+		claims.put("email", email);
+		claims.put("role", role);
+
+		return Jwts.builder()
+			.subject(String.valueOf(memberId))
+			.claims(claims)
+			.issuedAt(now)
+			.expiration(expiry)
+			.signWith(refreshTokenPrivateKey)
+			.compact();
+	}
+
+	public boolean validateAccessToken(final String token) {
+		try {
+			accessTokenParser.parseSignedClaims(token);
+			return true;
+		} catch (ExpiredJwtException e) {
+			throw new AuthException(AuthErrorType.EXPIRED_TOKEN);
+		} catch (JwtException | IllegalArgumentException e) {
+			throw new AuthException(AuthErrorType.INVALID_TOKEN);
+		}
+	}
+
+	public boolean validateRefreshToken(final String token) {
+		try {
+			refreshTokenParser.parseSignedClaims(token);
+			return true;
+		} catch (ExpiredJwtException e) {
+			throw new AuthException(AuthErrorType.EXPIRED_TOKEN);
+		} catch (JwtException | IllegalArgumentException e) {
+			throw new AuthException(AuthErrorType.INVALID_TOKEN);
+		}
+	}
+
+	public Claims extractAccessTokenPayload(final String accessToken) {
+		try {
+			return accessTokenParser.parseSignedClaims(accessToken).getPayload();
+		} catch (JwtException | IllegalArgumentException e) {
+			throw new AuthException(AuthErrorType.INVALID_TOKEN);
+		}
+	}
+
+	public Claims extractRefreshTokenPayload(final String refreshToken) {
+		try {
+			return refreshTokenParser.parseSignedClaims(refreshToken).getPayload();
+		} catch (JwtException | IllegalArgumentException e) {
+			throw new AuthException(AuthErrorType.INVALID_TOKEN);
+		}
+	}
+	public String resolveAccessToken(String authorizationHeader) {
+		final String BEARER_PREFIX = "Bearer ";
+		if (authorizationHeader != null && authorizationHeader.startsWith(BEARER_PREFIX)) {
+			return authorizationHeader.substring(BEARER_PREFIX.length());
+		}
+		return null;
+	}
+
+	public String resolveRefreshToken(HttpServletRequest request) {
+		if (request.getCookies() == null) {
+			return null;
+		}
+
+		for (Cookie cookie : request.getCookies()) {
+			if ("refreshToken".equals(cookie.getName())) {
+				return cookie.getValue();
+			}
+		}
+		return null;
+	}
+
+	public LocalDateTime extractExpiration(String refreshToken) {
+		Date expiration = extractRefreshTokenPayload(refreshToken).getExpiration();
+		return expiration.toInstant().atZone(ZoneId.systemDefault()).toLocalDateTime();
+	}
+
+	public String extractSubject(String refreshToken) {
+		return extractRefreshTokenPayload(refreshToken).getSubject();
+	}
+}

--- a/src/main/java/kr/mywork/domain/auth/service/MemberDetailService.java
+++ b/src/main/java/kr/mywork/domain/auth/service/MemberDetailService.java
@@ -1,0 +1,33 @@
+package kr.mywork.domain.auth.service;
+
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+import kr.mywork.domain.auth.dto.MemberDetails;
+import kr.mywork.domain.auth.errors.AuthErrorType;
+import kr.mywork.domain.auth.errors.AuthException;
+import kr.mywork.domain.member.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class MemberDetailService implements UserDetailsService {
+
+	private final MemberRepository memberRepository;
+
+	@Override
+	public MemberDetails loadUserByUsername(final String email) throws UsernameNotFoundException {
+		return memberRepository.findByEmailAndDeletedFalse(email)
+			.map(member -> {
+				return new MemberDetails(
+					member.getId(),
+					member.getEmail(),
+					member.getPassword(),
+					new SimpleGrantedAuthority(member.getRole().getRoleName())
+				);
+			})
+			.orElseThrow(() -> new AuthException(AuthErrorType.AUTHENTICATION_FAILED));
+	}
+}

--- a/src/main/java/kr/mywork/domain/auth/service/TokenAuthenticationService.java
+++ b/src/main/java/kr/mywork/domain/auth/service/TokenAuthenticationService.java
@@ -1,0 +1,35 @@
+package kr.mywork.domain.auth.service;
+
+import io.jsonwebtoken.Claims;
+import kr.mywork.domain.auth.dto.MemberDetails;
+import kr.mywork.domain.member.model.MemberRole;
+
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+
+import java.util.UUID;
+
+public class TokenAuthenticationService {
+
+	private final JwtTokenProvider jwtTokenProvider;
+
+	public TokenAuthenticationService(JwtTokenProvider jwtTokenProvider) {
+		this.jwtTokenProvider = jwtTokenProvider;
+	}
+
+	public MemberDetails extractMemberDetailsFromAccessToken(String accessToken) {
+		Claims claims = jwtTokenProvider.extractAccessTokenPayload(accessToken);
+
+		UUID memberId = UUID.fromString(claims.get("memberId", String.class));
+		String email = claims.get("email", String.class);
+		String role = claims.get("role", String.class);
+
+		MemberRole memberRole = MemberRole.of(role);
+
+		return new MemberDetails(
+			memberId,
+			email,
+			null,
+			new SimpleGrantedAuthority(memberRole.getRoleName())
+		);
+	}
+}

--- a/src/main/java/kr/mywork/domain/auth/service/TokenService.java
+++ b/src/main/java/kr/mywork/domain/auth/service/TokenService.java
@@ -1,0 +1,85 @@
+package kr.mywork.domain.auth.service;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+import org.springframework.stereotype.Service;
+
+import io.jsonwebtoken.Claims;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import kr.mywork.domain.auth.dto.response.TokenResponse;
+import kr.mywork.domain.auth.errors.AuthErrorType;
+import kr.mywork.domain.auth.errors.AuthException;
+import kr.mywork.domain.auth.model.BlacklistedRefreshToken;
+import kr.mywork.domain.auth.repository.BlacklistedRefreshTokenRepository;
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class TokenService {
+
+	private final JwtTokenProvider jwtTokenProvider;
+	private final BlacklistedRefreshTokenRepository blacklistedRefreshTokenRepository;
+
+	public void logout(HttpServletRequest request, HttpServletResponse response) {
+		String refreshToken = resolveRefreshTokenFromCookie(request);
+
+		if (refreshToken != null && jwtTokenProvider.validateRefreshToken(refreshToken)) {
+			LocalDateTime expiresAt = jwtTokenProvider.extractExpiration(refreshToken);
+			blacklistedRefreshTokenRepository.save(new BlacklistedRefreshToken(refreshToken, expiresAt));
+		}
+
+		clearRefreshTokenCookie(response);
+	}
+
+	public TokenResponse reissue(HttpServletRequest request, HttpServletResponse response) {
+		String refreshToken = resolveRefreshTokenFromCookie(request);
+
+		if (refreshToken == null) {
+			throw new AuthException(AuthErrorType.REFRESH_TOKEN_NOT_FOUND);
+		}
+
+		if (!jwtTokenProvider.validateRefreshToken(refreshToken)) {
+			throw new AuthException(AuthErrorType.INVALID_TOKEN);
+		}
+
+		if (isRefreshTokenBlacklisted(refreshToken)) {
+			throw new AuthException(AuthErrorType.INVALID_TOKEN);
+		}
+
+		Claims claims = jwtTokenProvider.extractRefreshTokenPayload(refreshToken);
+
+		UUID memberId = UUID.fromString(claims.getSubject());
+		String email = claims.get("email", String.class);
+		String role = claims.get("role", String.class);
+
+		String newAccessToken = jwtTokenProvider.createAccessToken(memberId, email, role);
+		LocalDateTime expiresAt = jwtTokenProvider.extractExpiration(refreshToken);
+
+		return new TokenResponse(newAccessToken, expiresAt);
+	}
+
+	private String resolveRefreshTokenFromCookie(HttpServletRequest request) {
+		if (request.getCookies() == null) return null;
+		for (Cookie cookie : request.getCookies()) {
+			if ("refreshToken".equals(cookie.getName())) {
+				return cookie.getValue();
+			}
+		}
+		return null;
+	}
+
+	private void clearRefreshTokenCookie(HttpServletResponse response) {
+		Cookie cookie = new Cookie("refreshToken", null);
+		cookie.setHttpOnly(true);
+		cookie.setPath("/");
+		cookie.setMaxAge(0);
+		response.addCookie(cookie);
+	}
+
+	private boolean isRefreshTokenBlacklisted(String token) {
+		return blacklistedRefreshTokenRepository.existsByToken(token);
+	}
+}

--- a/src/main/java/kr/mywork/infrastructure/auth/rdb/JpaBlacklistedRefreshTokenRepository.java
+++ b/src/main/java/kr/mywork/infrastructure/auth/rdb/JpaBlacklistedRefreshTokenRepository.java
@@ -1,0 +1,15 @@
+package kr.mywork.infrastructure.auth.rdb;
+
+import java.util.Optional;
+import java.util.UUID;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import kr.mywork.domain.auth.model.BlacklistedRefreshToken;
+
+public interface JpaBlacklistedRefreshTokenRepository extends JpaRepository<BlacklistedRefreshToken, UUID> {
+	Optional<BlacklistedRefreshToken> findByToken(String token);
+	boolean existsByToken(String token);
+}
+
+

--- a/src/main/java/kr/mywork/infrastructure/auth/rdb/QueryDslBlacklistedRefreshTokenRepository.java
+++ b/src/main/java/kr/mywork/infrastructure/auth/rdb/QueryDslBlacklistedRefreshTokenRepository.java
@@ -1,0 +1,47 @@
+package kr.mywork.infrastructure.auth.rdb;
+
+
+import static kr.mywork.domain.auth.model.QBlacklistedRefreshToken.*;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+
+import kr.mywork.domain.auth.model.BlacklistedRefreshToken;
+import kr.mywork.domain.auth.repository.BlacklistedRefreshTokenRepository;
+import lombok.RequiredArgsConstructor;
+
+@Repository
+@RequiredArgsConstructor
+@Transactional
+public class QueryDslBlacklistedRefreshTokenRepository implements BlacklistedRefreshTokenRepository {
+
+	private final JpaBlacklistedRefreshTokenRepository blacklistedRefreshTokenRepository;
+	private final JPAQueryFactory queryFactory;
+
+	@Override
+	public BlacklistedRefreshToken save(final BlacklistedRefreshToken token) {
+		return blacklistedRefreshTokenRepository.save(token);
+	}
+
+	@Override
+	public Optional<BlacklistedRefreshToken> findByToken(final String token) {
+		return blacklistedRefreshTokenRepository.findByToken(token);
+	}
+
+	@Override
+	public boolean existsByToken(final String token) {
+		return blacklistedRefreshTokenRepository.existsByToken(token);
+	}
+
+	@Override
+	public void deleteExpiredTokens() {
+		queryFactory.delete(blacklistedRefreshToken)
+			.where(blacklistedRefreshToken.expiresAt.before(LocalDateTime.now()))
+			.execute();
+	}
+}

--- a/src/main/java/kr/mywork/interfaces/auth/controller/AuthController.java
+++ b/src/main/java/kr/mywork/interfaces/auth/controller/AuthController.java
@@ -1,0 +1,31 @@
+package kr.mywork.interfaces.auth.controller;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import kr.mywork.common.api.support.response.ApiResponse;
+import kr.mywork.domain.auth.dto.response.TokenResponse;
+import kr.mywork.interfaces.auth.dto.response.TokenWebResponse;
+import kr.mywork.domain.auth.service.TokenService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api")
+@RequiredArgsConstructor
+public class AuthController {
+
+	private final TokenService tokenService;
+
+	@PostMapping("/logout")
+	public ApiResponse<Void> logout(HttpServletRequest request, HttpServletResponse response) {
+		tokenService.logout(request, response);
+		return ApiResponse.success((Void) null);
+	}
+
+	@PostMapping("/reissue")
+	public ApiResponse<TokenWebResponse> reissue(HttpServletRequest request, HttpServletResponse response) {
+		TokenResponse tokenResponse = tokenService.reissue(request, response);
+		return ApiResponse.success(TokenWebResponse.from(tokenResponse));
+	}
+}

--- a/src/main/java/kr/mywork/interfaces/auth/dto/request/LoginWebRequest.java
+++ b/src/main/java/kr/mywork/interfaces/auth/dto/request/LoginWebRequest.java
@@ -1,0 +1,4 @@
+package kr.mywork.interfaces.auth.dto.request;
+
+public record LoginWebRequest(String email, String password) {
+}

--- a/src/main/java/kr/mywork/interfaces/auth/dto/response/TokenWebResponse.java
+++ b/src/main/java/kr/mywork/interfaces/auth/dto/response/TokenWebResponse.java
@@ -1,0 +1,21 @@
+package kr.mywork.interfaces.auth.dto.response;
+
+import java.time.LocalDateTime;
+
+import kr.mywork.domain.auth.dto.response.TokenResponse;
+import lombok.Getter;
+
+@Getter
+public class TokenWebResponse {
+	private final String accessToken;
+	private final LocalDateTime expiresAt;
+
+	public TokenWebResponse(String accessToken, LocalDateTime expiresAt) {
+		this.accessToken = accessToken;
+		this.expiresAt = expiresAt;
+	}
+
+	public static TokenWebResponse from(TokenResponse tokenResponse) {
+		return new TokenWebResponse(tokenResponse.getAccessToken(), tokenResponse.getExpiresAt());
+	}
+}

--- a/src/main/java/kr/mywork/interfaces/auth/exception/CommonAuthenticationException.java
+++ b/src/main/java/kr/mywork/interfaces/auth/exception/CommonAuthenticationException.java
@@ -1,0 +1,15 @@
+package kr.mywork.interfaces.auth.exception;
+
+import kr.mywork.common.api.support.error.CommonErrorType;
+import lombok.Getter;
+
+@Getter
+public class CommonAuthenticationException extends RuntimeException {
+
+  private final CommonErrorType errorType;
+
+  public CommonAuthenticationException(CommonErrorType errorType) {
+    super(errorType.getMessage());
+    this.errorType = errorType;
+  }
+}

--- a/src/main/java/kr/mywork/interfaces/auth/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/kr/mywork/interfaces/auth/filter/JwtAuthenticationFilter.java
@@ -1,0 +1,75 @@
+package kr.mywork.interfaces.auth.filter;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import kr.mywork.common.api.support.response.ApiResponse;
+import kr.mywork.domain.auth.dto.MemberDetails;
+import kr.mywork.domain.auth.errors.AuthErrorType;
+import kr.mywork.domain.auth.service.JwtTokenProvider;
+import kr.mywork.domain.auth.service.TokenAuthenticationService;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+	private final JwtTokenProvider jwtTokenProvider;
+	private final TokenAuthenticationService tokenAuthenticationService;
+	private final ObjectMapper objectMapper;
+
+	public JwtAuthenticationFilter(
+		JwtTokenProvider jwtTokenProvider,
+		TokenAuthenticationService tokenAuthenticationService,
+		ObjectMapper objectMapper
+	) {
+		this.jwtTokenProvider = jwtTokenProvider;
+		this.tokenAuthenticationService = tokenAuthenticationService;
+		this.objectMapper = objectMapper;
+	}
+
+	@Override
+	protected void doFilterInternal(
+		HttpServletRequest request,
+		HttpServletResponse response,
+		FilterChain filterChain
+	) throws ServletException, IOException {
+		try {
+			String token = jwtTokenProvider.resolveAccessToken(request.getHeader(HttpHeaders.AUTHORIZATION));
+
+			if (token != null && jwtTokenProvider.validateAccessToken(token)
+				&& SecurityContextHolder.getContext().getAuthentication() == null) {
+
+				MemberDetails memberDetails = tokenAuthenticationService.extractMemberDetailsFromAccessToken(token);
+
+				UsernamePasswordAuthenticationToken authentication = new UsernamePasswordAuthenticationToken(
+					memberDetails,
+					null,
+					memberDetails.getAuthorities()
+				);
+
+				SecurityContextHolder.getContext().setAuthentication(authentication);
+			}
+
+			filterChain.doFilter(request, response);
+
+		} catch (Exception e) {
+			response.setCharacterEncoding(StandardCharsets.UTF_8.name());
+			response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+			response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+
+			var apiError = ApiResponse.error(
+				AuthErrorType.INVALID_LOGIN.getErrorCode().name(),
+				AuthErrorType.INVALID_LOGIN.getMessage()
+			);
+			objectMapper.writeValue(response.getWriter(), apiError);
+		}
+	}
+}

--- a/src/main/java/kr/mywork/interfaces/auth/filter/JwtLoginFilter.java
+++ b/src/main/java/kr/mywork/interfaces/auth/filter/JwtLoginFilter.java
@@ -1,0 +1,63 @@
+package kr.mywork.interfaces.auth.filter;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import kr.mywork.common.api.support.error.CommonErrorType;
+import kr.mywork.interfaces.auth.dto.request.LoginWebRequest;
+import kr.mywork.domain.auth.dto.LoginTrialAuthenticationToken;
+import kr.mywork.interfaces.auth.exception.CommonAuthenticationException;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpHeaders;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.authentication.AbstractAuthenticationProcessingFilter;
+import org.springframework.util.ObjectUtils;
+
+import java.io.IOException;
+
+public class JwtLoginFilter extends AbstractAuthenticationProcessingFilter {
+
+	@Autowired
+	private final ObjectMapper objectMapper;
+
+	public JwtLoginFilter(String defaultFilterProcessesUrl, ObjectMapper objectMapper) {
+		super(defaultFilterProcessesUrl);
+		this.objectMapper = objectMapper;
+	}
+
+	@Override
+	public Authentication attemptAuthentication(HttpServletRequest request, HttpServletResponse response)
+		throws AuthenticationException {
+
+		try {
+			validateContentType(request.getHeader(HttpHeaders.CONTENT_TYPE));
+
+			final LoginWebRequest loginWebRequest = objectMapper.readValue(request.getReader(), LoginWebRequest.class);
+
+			validateLoginRequest(loginWebRequest);
+
+			final LoginTrialAuthenticationToken loginTrialAuthenticationToken = LoginTrialAuthenticationToken.create(
+				loginWebRequest.email(), loginWebRequest.password());
+
+			return getAuthenticationManager().authenticate(loginTrialAuthenticationToken);
+
+		} catch (IOException e) {
+			throw new CommonAuthenticationException(CommonErrorType.INVALID_JSON_INPUT);
+		}
+	}
+
+	private void validateContentType(final String contentTypeHeader) {
+		if (ObjectUtils.isEmpty(contentTypeHeader) || !contentTypeHeader.toLowerCase().startsWith("application/json")) {
+			throw new CommonAuthenticationException(CommonErrorType.INVALID_CONTENT_TYPE);
+		}
+	}
+
+	private void validateLoginRequest(final LoginWebRequest loginWebRequest) {
+		if (ObjectUtils.isEmpty(loginWebRequest.email()) || ObjectUtils.isEmpty(loginWebRequest.password())) {
+			throw new CommonAuthenticationException(CommonErrorType.INVALID_INPUT_VALUE);
+		}
+	}
+
+}

--- a/src/main/java/kr/mywork/interfaces/auth/handler/error/AuthControllerAdvice.java
+++ b/src/main/java/kr/mywork/interfaces/auth/handler/error/AuthControllerAdvice.java
@@ -1,0 +1,29 @@
+package kr.mywork.interfaces.auth.handler.error;
+
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import kr.mywork.common.api.support.response.ApiResponse;
+import kr.mywork.domain.auth.errors.AuthErrorType;
+import kr.mywork.domain.auth.errors.AuthException;
+
+@Order(Ordered.LOWEST_PRECEDENCE - 1)
+@RestControllerAdvice
+public class AuthControllerAdvice {
+
+	@ExceptionHandler(AuthException.class)
+	public ResponseEntity<ApiResponse<?>> handleAuthException(AuthException exception) {
+		final AuthErrorType errorType = exception.getErrorType();
+
+		HttpStatus status = (errorType == AuthErrorType.ACCESS_DENIED)
+			? HttpStatus.FORBIDDEN
+			: HttpStatus.UNAUTHORIZED;
+
+		return ResponseEntity.status(status)
+			.body(ApiResponse.error(errorType.getErrorCode().name(), errorType.getMessage()));
+	}
+}

--- a/src/main/java/kr/mywork/interfaces/auth/handler/error/JwtAccessDeniedHandler.java
+++ b/src/main/java/kr/mywork/interfaces/auth/handler/error/JwtAccessDeniedHandler.java
@@ -1,0 +1,37 @@
+package kr.mywork.interfaces.auth.handler.error;
+
+import java.io.IOException;
+
+import org.springframework.http.MediaType;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.web.access.AccessDeniedHandler;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import kr.mywork.common.api.support.response.ApiResponse;
+import kr.mywork.domain.auth.errors.AuthErrorType;
+
+public class JwtAccessDeniedHandler implements AccessDeniedHandler {
+
+	private final ObjectMapper objectMapper;
+
+	public JwtAccessDeniedHandler(ObjectMapper objectMapper) {
+		this.objectMapper = objectMapper;
+	}
+
+	@Override
+	public void handle(HttpServletRequest request, HttpServletResponse response, AccessDeniedException accessDeniedException) throws
+		IOException {
+		response.setStatus(HttpServletResponse.SC_FORBIDDEN);
+		response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+		response.setCharacterEncoding("UTF-8");
+
+		ApiResponse<?> errorResponse = ApiResponse.error(
+			AuthErrorType.ACCESS_DENIED.getErrorCode().name(),
+			AuthErrorType.ACCESS_DENIED.getMessage()
+		);
+		objectMapper.writeValue(response.getWriter(), errorResponse);
+	}
+}

--- a/src/main/java/kr/mywork/interfaces/auth/handler/error/JwtAuthenticationEntryPoint.java
+++ b/src/main/java/kr/mywork/interfaces/auth/handler/error/JwtAuthenticationEntryPoint.java
@@ -1,0 +1,36 @@
+package kr.mywork.interfaces.auth.handler.error;
+
+import java.io.IOException;
+
+import org.springframework.http.MediaType;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import kr.mywork.common.api.support.response.ApiResponse;
+import kr.mywork.domain.auth.errors.AuthErrorType;
+
+public class JwtAuthenticationEntryPoint implements AuthenticationEntryPoint {
+	private final ObjectMapper objectMapper;
+
+	public JwtAuthenticationEntryPoint(ObjectMapper objectMapper) {
+		this.objectMapper = objectMapper;
+	}
+
+	@Override
+	public void commence(HttpServletRequest request, HttpServletResponse response, AuthenticationException authException) throws
+		IOException {
+		response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+		response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+		response.setCharacterEncoding("UTF-8");
+
+		ApiResponse<?> errorResponse = ApiResponse.error(
+			AuthErrorType.AUTHENTICATION_FAILED.getErrorCode().name(),
+			AuthErrorType.AUTHENTICATION_FAILED.getMessage()
+		);
+		objectMapper.writeValue(response.getWriter(), errorResponse);
+	}
+}

--- a/src/main/java/kr/mywork/interfaces/auth/handler/error/LoginFailureHandler.java
+++ b/src/main/java/kr/mywork/interfaces/auth/handler/error/LoginFailureHandler.java
@@ -1,0 +1,40 @@
+package kr.mywork.interfaces.auth.handler.error;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import kr.mywork.common.api.support.error.CommonErrorType;
+import kr.mywork.common.api.support.response.ApiResponse;
+import kr.mywork.domain.auth.errors.AuthErrorType;
+
+import org.springframework.http.MediaType;
+import org.springframework.security.web.authentication.AuthenticationFailureHandler;
+import org.springframework.security.core.AuthenticationException;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
+public class LoginFailureHandler implements AuthenticationFailureHandler {
+
+    private final ObjectMapper objectMapper;
+
+    public LoginFailureHandler(ObjectMapper objectMapper) {
+        this.objectMapper = objectMapper;
+    }
+
+    @Override
+    public void onAuthenticationFailure(HttpServletRequest request,
+        HttpServletResponse response,
+        AuthenticationException exception) throws IOException {
+
+        response.setCharacterEncoding(StandardCharsets.UTF_8.name());
+        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+
+        CommonErrorType errorType = CommonErrorType.UNAUTHORIZED;
+        ApiResponse<?> apiResponse = ApiResponse.error(
+            AuthErrorType.ACCESS_DENIED.getErrorCode().name(),
+            AuthErrorType.ACCESS_DENIED.getMessage()
+        );
+        objectMapper.writeValue(response.getWriter(), apiResponse);
+    }
+}

--- a/src/main/java/kr/mywork/interfaces/auth/handler/success/LoginSuccessHandler.java
+++ b/src/main/java/kr/mywork/interfaces/auth/handler/success/LoginSuccessHandler.java
@@ -1,0 +1,66 @@
+package kr.mywork.interfaces.auth.handler.success;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import kr.mywork.common.api.support.response.ApiResponse;
+import kr.mywork.domain.auth.dto.MemberDetails;
+import kr.mywork.domain.auth.service.JwtTokenProvider;
+import kr.mywork.interfaces.auth.dto.response.TokenWebResponse;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.time.LocalDateTime;
+
+public class LoginSuccessHandler implements AuthenticationSuccessHandler {
+
+	private final JwtTokenProvider jwtTokenProvider;
+	private final ObjectMapper objectMapper;
+
+	public LoginSuccessHandler(JwtTokenProvider jwtTokenProvider,
+		ObjectMapper objectMapper) {
+		this.jwtTokenProvider = jwtTokenProvider;
+		this.objectMapper = objectMapper;
+	}
+
+	@Override
+	public void onAuthenticationSuccess(HttpServletRequest request,
+		HttpServletResponse response,
+		Authentication authentication) throws IOException {
+
+		final MemberDetails memberDetails = (MemberDetails) authentication.getPrincipal();
+
+		final String accessToken = jwtTokenProvider.createAccessToken(
+			memberDetails.getId(),
+			memberDetails.getEmail(),
+			memberDetails.getAuthorityAsStr()
+		);
+
+		final String refreshToken = jwtTokenProvider.createRefreshToken(
+			memberDetails.getId(),
+			memberDetails.getEmail(),
+			memberDetails.getAuthorityAsStr()
+		);
+
+		final LocalDateTime expiresAt = jwtTokenProvider.extractExpiration(refreshToken);
+
+		int maxAge = (int) (jwtTokenProvider.getRefreshTokenExpirationMillis() / 1000);
+
+		Cookie cookie = new Cookie("refreshToken", refreshToken);
+		cookie.setHttpOnly(true);
+		cookie.setPath("/");
+		cookie.setMaxAge(maxAge);
+		response.addCookie(cookie);
+
+		TokenWebResponse tokenWebResponse = new TokenWebResponse(accessToken, expiresAt);
+
+		response.setCharacterEncoding(StandardCharsets.UTF_8.name());
+		response.setStatus(HttpServletResponse.SC_OK);
+		response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+		objectMapper.writeValue(response.getWriter(), ApiResponse.success(tokenWebResponse));
+	}
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -21,3 +21,10 @@ company:
 member:
   page:
     size: 10
+jwt:
+  access-token:
+    private-key: 126cab8a5d9087a27be4e2a0599682e2bab38e80201d1befa2dd9d55ecbdeac58bab0c84301ad9f9f8a71836825e5a7214e7a9fb17a8578418de6cfe9a15cbc7
+    expiration: 3600000
+  refresh-token:
+    private-key: 408a96ae4affd8bce03d11385d9a8dfbd4c0cbc9c5a83675864192dbb50eaa965acf2ef84e60bb1a38798f612caed4f383466a4be14957bf87370b62be71c2e1
+    expiration: 86400000

--- a/src/test/java/kr/mywork/docs/AuthDocumentationTest.java
+++ b/src/test/java/kr/mywork/docs/AuthDocumentationTest.java
@@ -1,0 +1,126 @@
+package kr.mywork.docs;
+
+import static com.epages.restdocs.apispec.ResourceDocumentation.*;
+import static org.springframework.restdocs.cookies.CookieDocumentation.*;
+import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.*;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.*;
+import static org.springframework.restdocs.payload.PayloadDocumentation.*;
+
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import java.util.Map;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.restdocs.payload.JsonFieldType;
+import org.springframework.test.context.jdbc.Sql;
+import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.test.web.servlet.ResultActions;
+
+import com.epages.restdocs.apispec.ResourceSnippetParameters;
+import com.jayway.jsonpath.JsonPath;
+
+import jakarta.servlet.http.Cookie;
+import kr.mywork.common.api.support.response.ResultType;
+import kr.mywork.domain.auth.service.JwtTokenProvider;
+
+public class AuthDocumentationTest extends RestDocsDocumentation{
+
+	@Autowired
+	private JwtTokenProvider jwtTokenProvider;
+
+	@Test
+	@DisplayName("로그인 성공")
+	@Sql("classpath:sql/member-auth.sql")
+	void 로그인_성공() throws Exception {
+		// given
+		final String email = "admin@example.com";
+		final String password = "1234";
+
+		final String requestBody = objectMapper.writeValueAsString(Map.of(
+			"email", email,
+			"password", password
+		));
+
+		// when
+		final ResultActions result = mockMvc.perform(
+			post("/api/login")
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(requestBody)
+		);
+
+		// then
+		result.andExpect(status().isOk())
+			.andExpect(jsonPath("$.result").value(ResultType.SUCCESS.name()))
+			.andExpect(jsonPath("$.data.accessToken").exists())
+			.andExpect(jsonPath("$.data.expiresAt").exists())
+			.andExpect(cookie().exists("refreshToken"))
+			.andDo(document("auth-login-success",
+				resource(
+					ResourceSnippetParameters.builder()
+						.tag("Auth API")
+						.summary("로그인 API")
+						.description("이메일과 비밀번호로 로그인한다. 성공 시 액세스 토큰과 리프레시 토큰이 발급된다.")
+						.requestFields(
+							fieldWithPath("email").type(JsonFieldType.STRING).description("이메일"),
+							fieldWithPath("password").type(JsonFieldType.STRING).description("비밀번호")
+						)
+						.responseFields(
+							fieldWithPath("result").type(JsonFieldType.STRING).description("응답 결과"),
+							fieldWithPath("data.accessToken").type(JsonFieldType.STRING).description("JWT 액세스 토큰"),
+							fieldWithPath("data.expiresAt").type(JsonFieldType.STRING).description("액세스 토큰 만료 시각"),
+							fieldWithPath("error").type(JsonFieldType.NULL).description("에러 정보")
+						)
+						.build()
+				)
+			));
+	}
+
+	@Test
+	@DisplayName("로그아웃 성공")
+	@Sql("classpath:sql/member-auth.sql")
+	void 로그아웃_성공() throws Exception {
+		// 1. 로그인해서 accessToken & refreshToken 획득
+		final String loginBody = objectMapper.writeValueAsString(Map.of(
+			"email", "admin@example.com",
+			"password", "1234"
+		));
+
+		final MvcResult loginResult = mockMvc.perform(post("/api/login")
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(loginBody))
+			.andExpect(status().isOk())
+			.andReturn();
+
+		String responseJson = loginResult.getResponse().getContentAsString();
+		String accessToken = JsonPath.read(responseJson, "$.data.accessToken");
+
+		Cookie refreshTokenCookie = loginResult.getResponse().getCookie("refreshToken");
+
+		// 2. 로그아웃 요청 + 문서화
+		mockMvc.perform(post("/api/logout")
+				.header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+				.cookie(refreshTokenCookie))
+			.andExpect(status().isOk())
+			.andDo(document("auth-logout",
+				requestHeaders(
+					headerWithName("Authorization").description("액세스 토큰 (Bearer)").getAttributes()
+				),
+				requestCookies(
+					cookieWithName("refreshToken").description("리프레시 토큰")
+				),
+				responseFields(
+					fieldWithPath("result").description("SUCCESS 또는 FAILURE"),
+					fieldWithPath("data").description("응답 데이터 (로그아웃은 null)").optional(),
+					fieldWithPath("error").description("에러 메시지 (없으면 null)").optional()
+				)
+			));
+	}
+
+
+
+}

--- a/src/test/java/kr/mywork/docs/CompanyDocumentationTest.java
+++ b/src/test/java/kr/mywork/docs/CompanyDocumentationTest.java
@@ -19,6 +19,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.restdocs.payload.JsonFieldType;
+import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.jdbc.Sql;
 import org.springframework.test.web.servlet.ResultActions;
 
@@ -34,6 +35,7 @@ public class CompanyDocumentationTest extends RestDocsDocumentation {
 
 	@Test
 	@DisplayName("회사 아이디 생성 테스트 성공")
+	@WithMockUser(roles = "SYSTEM_ADMIN")
 	void 회사_아이디_생성_테스트_성공() throws Exception {
 		// given, when
 		final ResultActions result = mockMvc.perform(
@@ -66,6 +68,7 @@ public class CompanyDocumentationTest extends RestDocsDocumentation {
 	}
 
 	@Test
+	@WithMockUser(roles = "SYSTEM_ADMIN")
 	@DisplayName("회사 생성 성공")
 	@Sql("classpath:sql/company-id.sql")
 	void 회사_생성_성공() throws Exception {
@@ -111,6 +114,7 @@ public class CompanyDocumentationTest extends RestDocsDocumentation {
 
 	@Test
 	@DisplayName("회사 생성 실패 - 아이디가 존재하지 않는 경우")
+	@WithMockUser(roles = "SYSTEM_ADMIN")
 	void 회사_생성_실패_아이디_미존재() throws Exception {
 		// given
 		UUID companyId = Generators.timeBasedEpochGenerator().generate(); // UUID ver7
@@ -157,6 +161,7 @@ public class CompanyDocumentationTest extends RestDocsDocumentation {
 	@Test
 	@DisplayName("회사 정보 업데이트 성공")
 	@Sql("classpath:sql/company-for-update.sql")
+	@WithMockUser(roles = "SYSTEM_ADMIN")
 	void 회사_정보_업데이트_성공() throws Exception {
 		//given
 		final UUID id = UUID.fromString("0196f7a6-10b6-7123-a2dc-32c3861ea55e");
@@ -202,6 +207,7 @@ public class CompanyDocumentationTest extends RestDocsDocumentation {
 	@Test
 	@DisplayName("회사 정보 업데이트 실패 - 잘못되 요청값(존재하지 않는 회사 타입 요청)")
 	@Sql("classpath:sql/company-for-update.sql")
+	@WithMockUser(roles = "SYSTEM_ADMIN")
 	void 회사_정보_업데이트_실패() throws Exception {
 		//given
 		final UUID id = UUID.fromString("0196f7a6-10b6-7123-a2dc-32c3861ea55e");
@@ -249,6 +255,7 @@ public class CompanyDocumentationTest extends RestDocsDocumentation {
 	@Test
 	@DisplayName("회사 삭제 성공")
 	@Sql("classpath:sql/company-delete.sql")
+	@WithMockUser(roles = "SYSTEM_ADMIN")
 	void 회사_삭제_성공() throws Exception {
 		UUID companyId = UUID.fromString("0196f7a6-10b6-7123-a2dc-32c3861ea55e"); // company-id.sql과 동일한 값
 		CompanyDeleteWebRequest deleteReq = new CompanyDeleteWebRequest(companyId);
@@ -291,6 +298,7 @@ public class CompanyDocumentationTest extends RestDocsDocumentation {
 	@Test
 	@DisplayName("회사 상세조회 성공")
 	@Sql("classpath:sql/company-detail.sql")
+	@WithMockUser(roles = "SYSTEM_ADMIN")
 	void 회사_상세조회_성공() throws Exception {
 		// given
 		UUID companyId = UUID.fromString("0196f7a6-10b6-7123-a2dc-32c3861ea55e"); // company-id.sql과 동일한 값
@@ -336,6 +344,7 @@ public class CompanyDocumentationTest extends RestDocsDocumentation {
 	@Test
 	@DisplayName("회사 목록 기본 조회 성공")
 	@Sql("classpath:sql/company-list.sql")
+	@WithMockUser(roles = "SYSTEM_ADMIN")
 	void 회사_목록_기본_조회_성공() throws Exception {
 		// given
 

--- a/src/test/java/kr/mywork/docs/MemberDocumentationTest.java
+++ b/src/test/java/kr/mywork/docs/MemberDocumentationTest.java
@@ -18,6 +18,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.restdocs.payload.JsonFieldType;
+import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.jdbc.Sql;
 import org.springframework.test.web.servlet.ResultActions;
 
@@ -33,6 +34,7 @@ public class MemberDocumentationTest extends RestDocsDocumentation {
 
 	@Test
 	@DisplayName("회사 직원 목록 조회 테스트 성공")
+	@WithMockUser(roles = "SYSTEM_ADMIN")
 	@Sql("classpath:sql/company-member-get.sql")
 	void 회사직원_조회_테스트_성공() throws Exception {
 		//given
@@ -76,6 +78,7 @@ public class MemberDocumentationTest extends RestDocsDocumentation {
 
 	@Test
 	@DisplayName("멤버 삭제 테스트 성공")
+	@WithMockUser(roles = "SYSTEM_ADMIN")
 	@Sql("classpath:sql/member-delete.sql")
 	void 멤버_삭제_테스트_성공() throws Exception {
 		//given
@@ -116,6 +119,7 @@ public class MemberDocumentationTest extends RestDocsDocumentation {
 
 	@Test
 	@DisplayName("멤버 생성 성공")
+	@WithMockUser(roles = "SYSTEM_ADMIN")
 	void 멤버_생성_성공() throws Exception {
 		//given
 		UUID companyId = UUID.fromString("0196f7a6-10b6-7123-a2dc-32c3861ea55e"); // UUID ver7
@@ -163,6 +167,7 @@ public class MemberDocumentationTest extends RestDocsDocumentation {
 
 	@Test
 	@DisplayName("회사 직원 조회 샐패 (page 검증)")
+	@WithMockUser(roles = "SYSTEM_ADMIN")
 	void 회사_직원_조회_실패_페이징() throws Exception {
 		final UUID id = UUID.fromString("0196f7a6-10b6-7123-a2dc-32c3861ea55e");
 

--- a/src/test/java/kr/mywork/docs/PostDocumentationTest.java
+++ b/src/test/java/kr/mywork/docs/PostDocumentationTest.java
@@ -13,6 +13,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.restdocs.payload.JsonFieldType;
+import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.jdbc.Sql;
 import org.springframework.test.web.servlet.ResultActions;
 
@@ -28,6 +29,7 @@ public class PostDocumentationTest extends RestDocsDocumentation {
 
 	@Test
 	@DisplayName("게시글 ID 생성 테스트")
+	@WithMockUser(roles = "SYSTEM_ADMIN")
 	void 게시글_아이디_생성_테스트_성공() throws Exception {
 
 		//given, when
@@ -63,6 +65,7 @@ public class PostDocumentationTest extends RestDocsDocumentation {
 	@Test
 	@DisplayName("게시글 생성 성공")
 	@Sql("classpath:sql/post-id.sql")
+	@WithMockUser(roles = "SYSTEM_ADMIN")
 	void 게시글_생성_성공() throws Exception {
 		// given
 		UUID postId = UUID.fromString("1234a9a9-90b6-9898-a9dc-92c9861aa98c"); // UUID ver7
@@ -106,6 +109,7 @@ public class PostDocumentationTest extends RestDocsDocumentation {
 
 	@Test
 	@DisplayName("게시글 생성 실패 - 아이디가 존재하지 않는 경우")
+	@WithMockUser(roles = "SYSTEM_ADMIN")
 	void 게시글_생성_실패_아이디_미존재() throws Exception {
 		// given
 		UUID postId = Generators.timeBasedEpochGenerator().generate(); // UUID ver7

--- a/src/test/java/kr/mywork/docs/ProjectStepDocumentationTest.java
+++ b/src/test/java/kr/mywork/docs/ProjectStepDocumentationTest.java
@@ -17,6 +17,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.restdocs.payload.JsonFieldType;
+import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.jdbc.Sql;
 import org.springframework.test.web.servlet.ResultActions;
 
@@ -33,6 +34,7 @@ public class ProjectStepDocumentationTest extends RestDocsDocumentation {
 
 	@Test
 	@DisplayName("프로젝트 단계 생성 성공")
+	@WithMockUser(roles = "SYSTEM_ADMIN")
 	void 프로젝트_단계_생성_성공() throws Exception {
 		// given
 		// TODO Project 생성 API 개발 후, ProjectId 생성 및 검증 샘플 데이터 추가 필요
@@ -81,6 +83,7 @@ public class ProjectStepDocumentationTest extends RestDocsDocumentation {
 	@Test
 	@DisplayName("프로젝트 단계 수정 성공")
 	@Sql("classpath:sql/project-step-update.sql")
+	@WithMockUser(roles = "SYSTEM_ADMIN")
 	void 프로젝트_단계_수정_성공() throws Exception {
 		// given
 		// TODO Project 생성 API 개발 후, ProjectId 생성 및 검증 샘플 데이터 추가 필요

--- a/src/test/java/kr/mywork/docs/RestDocsDocumentation.java
+++ b/src/test/java/kr/mywork/docs/RestDocsDocumentation.java
@@ -3,6 +3,7 @@ package kr.mywork.docs;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.documentationConfiguration;
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.modifyUris;
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
+import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 
 import org.junit.jupiter.api.BeforeEach;
@@ -44,6 +45,7 @@ abstract class RestDocsDocumentation {
 	public void setUp(RestDocumentationContextProvider restDocumentation) {
 		this.mockMvc = MockMvcBuilders
 			.webAppContextSetup(this.context)
+			.apply(springSecurity())
 			.addFilters(new CharacterEncodingFilter("UTF-8", true))
 			.apply(documentationConfiguration(restDocumentation)
 				.operationPreprocessors()

--- a/src/test/java/kr/mywork/docs/ReviewDocumentationTest.java
+++ b/src/test/java/kr/mywork/docs/ReviewDocumentationTest.java
@@ -16,9 +16,9 @@ import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.restdocs.payload.JsonFieldType;
-import org.springframework.test.context.jdbc.Sql;
+import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.ResultActions;
-
+import org.springframework.test.context.jdbc.Sql;
 import com.epages.restdocs.apispec.ResourceSnippet;
 import com.epages.restdocs.apispec.ResourceSnippetParameters;
 
@@ -30,6 +30,7 @@ public class ReviewDocumentationTest extends RestDocsDocumentation {
 
 	@Test
 	@DisplayName("리뷰 생성 테스트 성공")
+	@WithMockUser(roles = "SYSTEM_ADMIN")
 	void 리뷰_생성_테스트_성공() throws Exception {
 		// given
 		final UUID postId = UUID.fromString("01972f9b-232a-7dbe-aad2-3bffc0b78ced");

--- a/src/test/java/kr/mywork/infrastructure/company/rdb/QueryDslCompanyRepositoryTest.java
+++ b/src/test/java/kr/mywork/infrastructure/company/rdb/QueryDslCompanyRepositoryTest.java
@@ -12,6 +12,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.jdbc.Sql;
 
 import kr.mywork.base.annotations.RdbRepositoryTest;
@@ -29,6 +30,7 @@ class QueryDslCompanyRepositoryTest {
 	@Test
 	@DisplayName("기본 회사 목록 조회 성공")
 	@Sql("classpath:sql/company-list.sql")
+	@WithMockUser(roles = "SYSTEM_ADMIN")
 	void 기본_회사_목록_조회_성공() {
 		// given
 		int companyPageSize = 10;
@@ -48,6 +50,7 @@ class QueryDslCompanyRepositoryTest {
 	@Test
 	@DisplayName("회사 활성화 목록 조회 성공")
 	@Sql("classpath:sql/company-list.sql")
+	@WithMockUser(roles = "SYSTEM_ADMIN")
 	void 회사_활성화_목록_조회_성공() {
 		// given
 		String companyType = "DEV";
@@ -70,6 +73,7 @@ class QueryDslCompanyRepositoryTest {
 	@Test
 	@DisplayName("회사 검색어 목록 조회 성공 - 키워드 앞부분 일치")
 	@Sql("classpath:sql/company-list.sql")
+	@WithMockUser(roles = "SYSTEM_ADMIN")
 	void 회사_검색어_목록_조회_성공() {
 		// given
 		String companyType = "DEV";
@@ -90,6 +94,7 @@ class QueryDslCompanyRepositoryTest {
 	@ParameterizedTest
 	@MethodSource("companyListMethodSource")
 	@Sql("classpath:sql/company-list.sql")
+	@WithMockUser(roles = "SYSTEM_ADMIN")
 	void 회사_검색어_목록_갯수_조회_성공(final String companyType, final String keyword, final Boolean deleted, final Long expected) {
 		// given, when
 		final Long totalCount = companyRepository.countTotalCompaniesByCondition(companyType, keyword, deleted);

--- a/src/test/java/kr/mywork/interfaces/post/controller/ReviewControllerTest.java
+++ b/src/test/java/kr/mywork/interfaces/post/controller/ReviewControllerTest.java
@@ -20,6 +20,7 @@ import org.junit.jupiter.params.provider.MethodSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
@@ -47,6 +48,7 @@ class ReviewControllerTest {
 
 	@Test
 	@DisplayName("리뷰 생성 요청 성공")
+	@WithMockUser(roles = "SYSTEM_ADMIN")
 	void 리뷰_생성_요청_성공() throws Exception {
 		// given
 		final UUID postId = UUID.fromString("01972f9b-232a-7dbe-aad2-3bffc0b78ced");
@@ -75,6 +77,7 @@ class ReviewControllerTest {
 
 	@Test
 	@DisplayName("리뷰 생성 요청 입력 값 실패 (빈 코멘트)")
+	@WithMockUser(roles = "SYSTEM_ADMIN")
 	void 리뷰_생성_요청_입력_값_실패() throws Exception {
 		// given
 		final UUID postId = UUID.fromString("01972f9b-232a-7dbe-aad2-3bffc0b78ced");

--- a/src/test/java/kr/mywork/interfaces/project_step/controller/ProjectStepControllerTest.java
+++ b/src/test/java/kr/mywork/interfaces/project_step/controller/ProjectStepControllerTest.java
@@ -21,6 +21,7 @@ import org.junit.jupiter.params.provider.MethodSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
@@ -49,6 +50,7 @@ class ProjectStepControllerTest {
 
 	@Test
 	@DisplayName("프로젝트 단계 목록 생성 성공")
+	@WithMockUser(roles = "SYSTEM_ADMIN")
 	void 프로젝트_단계_목록_생성_성공() throws Exception {
 		// given
 		when(projectStepService.saveAll(any(), any())).thenReturn(7);
@@ -82,6 +84,7 @@ class ProjectStepControllerTest {
 	@ParameterizedTest
 	@MethodSource("projectStepFailMethodSource")
 	@DisplayName("프로젝트 단계 목록 유효하지 않은 입력값 실패")
+	@WithMockUser(roles = "SYSTEM_ADMIN")
 	void 프로젝트_단계_목록_유효하지_않은_입력값_실패(
 		final UUID projectId, final List<ProjectStepCreateWebRequest> projectStepCreateWebRequests) throws Exception {
 		// given
@@ -126,6 +129,7 @@ class ProjectStepControllerTest {
 	@ParameterizedTest
 	@MethodSource("projectStepUpdateFileMethodSource")
 	@DisplayName("프로젝트 단계 수정 유효하지 않은 입력값 실패")
+	@WithMockUser(roles = "SYSTEM_ADMIN")
 	void 프로젝트_단계_수정_유효하지_않은_입력값_실패(
 		final UUID projectId, final List<ProjectStepUpdateWebRequest> projectStepUpdateWebRequests) throws Exception {
 		// given

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -15,3 +15,10 @@ company:
 member:
   page:
     size: 10
+jwt:
+  access-token:
+    private-key: 126cab8a5d9087a27be4e2a0599682e2bab38e80201d1befa2dd9d55ecbdeac58bab0c84301ad9f9f8a71836825e5a7214e7a9fb17a8578418de6cfe9a15cbc7
+    expiration: 3600000
+  refresh-token:
+    private-key: 408a96ae4affd8bce03d11385d9a8dfbd4c0cbc9c5a83675864192dbb50eaa965acf2ef84e60bb1a38798f612caed4f383466a4be14957bf87370b62be71c2e1
+    expiration: 86400000

--- a/src/test/resources/sql/member-auth.sql
+++ b/src/test/resources/sql/member-auth.sql
@@ -1,0 +1,19 @@
+INSERT INTO member (
+    id, name, email, password, role, birth_date, phone_number,
+    company_id, department, position, created_at, modified_at, deleted
+)
+VALUES (
+           UNHEX(REPLACE('0196f7a6-10b6-7123-a2dc-32c3861ea55e', '-', '')),
+           '관리자',
+           'admin@example.com',
+           '$2a$12$0Q8Lv6HuY2k3/uP7.dfr1eTl0nMpEqD2kkJ7OJDDK2F4KrwKky1qm',  -- 'password123' bcrypt
+           'SYSTEM_ADMIN',
+           NOW(),
+           '010-1234-5678',
+           UNHEX(REPLACE('0196f7a6-10b6-7123-a2dc-32c3861ea55e', '-', '')),
+           '개발팀',
+           'CTO',
+           NOW(),
+           NOW(),
+           false
+       );


### PR DESCRIPTION
## 📌 개요

- JWT 기반 인증 및 인가 기능 전체 구현
- 로그인, 토큰 발급/재발급, 블랙리스트 처리, 예외 핸들링, 문서화까지 포함

## 🛠️ 변경 사항

- 로그인 요청/응답 DTO 정의 (LoginWebRequest, TokenWebResponse)
- 커스텀 인증 토큰 (LoginTrialAuthenticationToken, LoginSuccessAuthenticationToken) 구현
- JWT 로그인 필터 및 인증 필터 구현
- 로그인 성공/실패 핸들러 추가
- JwtTokenProvider를 통한 Access/RefreshToken 생성 및 검증
- RefreshToken 블랙리스트 처리 기능 구현
- AuthController에서 로그인 및 토큰 재발급 API 구현
- 예외 핸들러 및 에러 코드 분리 처리
- application.yml에 임의 키(private-key) 등록
- 인증 관련 RestDocs 테스트 추가 (AuthDocumentationTest)
- 관련 테스트 SQL (member-auth.sql) 및 컨트롤러/QueryDSL 테스트 보완

## ✅ 주요 체크 포인트

- [ ] JwtTokenProvider에서 토큰 생성/검증 로직 안전하게 동작하는지
- [ ]  로그인/토큰 재발급 요청 흐름이 올바르게 구성되었는지
- [ ]  인증 실패 시 일관된 예외 응답 포맷이 출력되는지
- [ ]  테스트 RestDocs가 정상적으로 생성되는지

## 🔁 테스트 결과

- 어떻게 테스트했는지, 테스트 결과는 어땠는지 설명해주세요.

## 🔗 연관된 이슈

- 해당 PR 과 연관된 이슈를 연결해 주세요.
- 에:
  - `- #10` - 이슈번호 10번을 연결할 수 있어요.

<br>

## 📑 레퍼런스

- 참고한 레퍼런스를 공유해주세요.
- 에:
    - `[링크 제목](링크)`
