### PR TITLE
[fix] spring security 추가로 인한 테스트 빌드 실패 이슈

### DIFF
--- a/src/test/java/kr/mywork/docs/AuthDocumentationTest.java
+++ b/src/test/java/kr/mywork/docs/AuthDocumentationTest.java
@@ -75,8 +75,10 @@ public class AuthDocumentationTest extends RestDocsDocumentation {
 							fieldWithPath("result").type(JsonFieldType.STRING).description("응답 결과"),
 							fieldWithPath("data.accessToken").type(JsonFieldType.STRING).description("JWT 액세스 토큰"),
 							fieldWithPath("data.expiresAt").type(JsonFieldType.STRING).description("액세스 토큰 만료 시각"),
-							fieldWithPath("error").type(JsonFieldType.NULL).description("에러 정보")
-						)
+							fieldWithPath("data.memberId").type(JsonFieldType.STRING).description("사용자 아이디"),
+							fieldWithPath("data.memberName").type(JsonFieldType.STRING).description("사용자 이름"),
+							fieldWithPath("data.memberRole").type(JsonFieldType.STRING).description("사용자 역할"),
+							fieldWithPath("error").type(JsonFieldType.NULL).description("에러 정보"))
 						.build()
 				)
 			));

--- a/src/test/java/kr/mywork/docs/CompanyDocumentationTest.java
+++ b/src/test/java/kr/mywork/docs/CompanyDocumentationTest.java
@@ -19,7 +19,6 @@ import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.restdocs.payload.JsonFieldType;
-import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.jdbc.Sql;
 import org.springframework.test.web.servlet.ResultActions;
 
@@ -36,7 +35,6 @@ public class CompanyDocumentationTest extends RestDocsDocumentation {
 
 	@Test
 	@DisplayName("회사 아이디 생성 테스트 성공")
-	@WithMockUser(roles = "SYSTEM_ADMIN")
 	void 회사_아이디_생성_테스트_성공() throws Exception {
 		// given
 		final String accessToken = createSystemAccessToken();
@@ -74,7 +72,6 @@ public class CompanyDocumentationTest extends RestDocsDocumentation {
 	}
 
 	@Test
-	@WithMockUser(roles = "SYSTEM_ADMIN")
 	@DisplayName("회사 생성 성공")
 	@Sql("classpath:sql/company-id.sql")
 	void 회사_생성_성공() throws Exception {
@@ -125,7 +122,6 @@ public class CompanyDocumentationTest extends RestDocsDocumentation {
 
 	@Test
 	@DisplayName("회사 생성 실패 - 아이디가 존재하지 않는 경우")
-	@WithMockUser(roles = "SYSTEM_ADMIN")
 	void 회사_생성_실패_아이디_미존재() throws Exception {
 		// given
 		UUID companyId = Generators.timeBasedEpochGenerator().generate(); // UUID ver7
@@ -172,7 +168,6 @@ public class CompanyDocumentationTest extends RestDocsDocumentation {
 	@Test
 	@DisplayName("회사 정보 업데이트 성공")
 	@Sql("classpath:sql/company-for-update.sql")
-	@WithMockUser(roles = "SYSTEM_ADMIN")
 	void 회사_정보_업데이트_성공() throws Exception {
 		//given
 		final String accessToken = createSystemAccessToken();
@@ -222,7 +217,6 @@ public class CompanyDocumentationTest extends RestDocsDocumentation {
 	@Test
 	@DisplayName("회사 정보 업데이트 실패 - 잘못되 요청값(존재하지 않는 회사 타입 요청)")
 	@Sql("classpath:sql/company-for-update.sql")
-	@WithMockUser(roles = "SYSTEM_ADMIN")
 	void 회사_정보_업데이트_실패() throws Exception {
 		//given
 		final String accessToken = createSystemAccessToken();
@@ -274,7 +268,6 @@ public class CompanyDocumentationTest extends RestDocsDocumentation {
 	@Test
 	@DisplayName("회사 삭제 성공")
 	@Sql("classpath:sql/company-delete.sql")
-	@WithMockUser(roles = "SYSTEM_ADMIN")
 	void 회사_삭제_성공() throws Exception {
 		final String accessToken = createSystemAccessToken();
 
@@ -370,7 +363,6 @@ public class CompanyDocumentationTest extends RestDocsDocumentation {
 	@Test
 	@DisplayName("회사 목록 기본 조회 성공")
 	@Sql("classpath:sql/company-list.sql")
-	@WithMockUser(roles = "SYSTEM_ADMIN")
 	void 회사_목록_기본_조회_성공() throws Exception {
 		// given
 		final String accessToken = createSystemAccessToken();

--- a/src/test/java/kr/mywork/docs/MemberDocumentationTest.java
+++ b/src/test/java/kr/mywork/docs/MemberDocumentationTest.java
@@ -212,6 +212,8 @@ public class MemberDocumentationTest extends RestDocsDocumentation {
 	@Sql("classpath:sql/member-update.sql")
 	void 멤버_정보_업데이트_성공() throws Exception {
 		//given
+		final String accessToken = createDevAdminAccessToken();
+
 		UUID memberId = UUID.fromString("6516f3fe-057b-efdc-9aa9-87bf7b33a1d0");
 		UUID companyId = UUID.fromString("0196f7a6-10b6-7123-a2dc-32c3861ea55e");
 		LocalDateTime birthDate = LocalDateTime.parse("2000-07-25T14:30:00");
@@ -223,7 +225,10 @@ public class MemberDocumentationTest extends RestDocsDocumentation {
 
 		//when
 		final ResultActions result = mockMvc.perform(
-			put("/api/member").contentType(MediaType.APPLICATION_JSON).content(requestBody));
+			put("/api/member")
+				.contentType(MediaType.APPLICATION_JSON)
+				.header(HttpHeaders.AUTHORIZATION, toBearerAuthorizationHeader(accessToken))
+				.content(requestBody));
 		//then
 		result.andExpectAll(status().isOk(), jsonPath("$.result").value(ResultType.SUCCESS.name()),
 				jsonPath("$.data").exists(), jsonPath("$.error").doesNotExist())
@@ -247,13 +252,16 @@ public class MemberDocumentationTest extends RestDocsDocumentation {
 	@Sql("classpath:sql/member-search.sql")
 	void 멤버_조회_성공() throws Exception {
 		//given
+		final String accessToken = createDevAdminAccessToken();
+
 		//when
 		final ResultActions result = mockMvc.perform(
 			get("/api/member")
 				.param("page","1")
 				.param("keyword","기획팀")
 				.param("keywordType","DEPARTMENT")
-				.contentType(MediaType.APPLICATION_JSON));
+				.contentType(MediaType.APPLICATION_JSON)
+				.header(HttpHeaders.AUTHORIZATION, toBearerAuthorizationHeader(accessToken)));
 		//then
 		result.andExpectAll(status().isOk(), jsonPath("$.result").value(ResultType.SUCCESS.name()),
 				jsonPath("$.data").exists(), jsonPath("$.error").doesNotExist())

--- a/src/test/java/kr/mywork/docs/MemberDocumentationTest.java
+++ b/src/test/java/kr/mywork/docs/MemberDocumentationTest.java
@@ -8,7 +8,6 @@ import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuild
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.put;
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
-import static org.springframework.restdocs.snippet.Attributes.key;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -20,7 +19,6 @@ import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.restdocs.payload.JsonFieldType;
-import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.jdbc.Sql;
 import org.springframework.test.web.servlet.ResultActions;
 
@@ -37,7 +35,6 @@ public class MemberDocumentationTest extends RestDocsDocumentation {
 
 	@Test
 	@DisplayName("회사 직원 목록 조회 테스트 성공")
-	@WithMockUser(roles = "SYSTEM_ADMIN")
 	@Sql("classpath:sql/company-member-get.sql")
 	void 회사직원_조회_테스트_성공() throws Exception {
 		//given
@@ -85,7 +82,6 @@ public class MemberDocumentationTest extends RestDocsDocumentation {
 
 	@Test
 	@DisplayName("멤버 삭제 테스트 성공")
-	@WithMockUser(roles = "SYSTEM_ADMIN")
 	@Sql("classpath:sql/member-delete.sql")
 	void 멤버_삭제_테스트_성공() throws Exception {
 		//given
@@ -128,7 +124,6 @@ public class MemberDocumentationTest extends RestDocsDocumentation {
 
 	@Test
 	@DisplayName("멤버 생성 성공")
-	@WithMockUser(roles = "SYSTEM_ADMIN")
 	void 멤버_생성_성공() throws Exception {
 		//given
 		final String accessToken = createSystemAccessToken();
@@ -175,7 +170,6 @@ public class MemberDocumentationTest extends RestDocsDocumentation {
 
 	@Test
 	@DisplayName("회사 직원 조회 샐패 (page 검증)")
-	@WithMockUser(roles = "SYSTEM_ADMIN")
 	void 회사_직원_조회_실패_페이징() throws Exception {
 		final UUID id = UUID.fromString("0196f7a6-10b6-7123-a2dc-32c3861ea55e");
 

--- a/src/test/java/kr/mywork/docs/PostDocumentationTest.java
+++ b/src/test/java/kr/mywork/docs/PostDocumentationTest.java
@@ -2,7 +2,10 @@ package kr.mywork.docs;
 
 import static com.epages.restdocs.apispec.MockMvcRestDocumentationWrapper.document;
 import static com.epages.restdocs.apispec.ResourceDocumentation.headerWithName;
+import static com.epages.restdocs.apispec.ResourceDocumentation.parameterWithName;
 import static com.epages.restdocs.apispec.ResourceDocumentation.resource;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.delete;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.put;
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
@@ -16,7 +19,6 @@ import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.restdocs.payload.JsonFieldType;
-import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.jdbc.Sql;
 import org.springframework.test.web.servlet.ResultActions;
 
@@ -71,7 +73,6 @@ public class PostDocumentationTest extends RestDocsDocumentation {
 	@Test
 	@DisplayName("게시글 생성 성공")
 	@Sql("classpath:sql/post-id.sql")
-	@WithMockUser(roles = "SYSTEM_ADMIN")
 	void 게시글_생성_성공() throws Exception {
 		// given
 		final String accessToken = createUserAccessToken();

--- a/src/test/java/kr/mywork/docs/PostDocumentationTest.java
+++ b/src/test/java/kr/mywork/docs/PostDocumentationTest.java
@@ -108,8 +108,7 @@ public class PostDocumentationTest extends RestDocsDocumentation {
 				.description("발급받은 게시글 아이디를 통해 게시글를 생성한다.")
 				.requestHeaders(
 					headerWithName(HttpHeaders.CONTENT_TYPE).description("컨텐츠 타입"),
-					headerWithName(HttpHeaders.AUTHORIZATION).description("엑세스 토큰")
-					)
+					headerWithName(HttpHeaders.AUTHORIZATION).description("엑세스 토큰"))
 				.responseFields(
 					fieldWithPath("result").type(JsonFieldType.STRING).description("응답 결과"),
 					fieldWithPath("data.postId").type(JsonFieldType.STRING).description("생성한 게시글 아이디"),
@@ -218,59 +217,67 @@ public class PostDocumentationTest extends RestDocsDocumentation {
 		);
 	}
 
-   @Test
-    @DisplayName("게시글 단건 조회 성공")
-    @Sql("classpath:sql/post-for-get.sql")
-    void 게시글_단건_조회_성공() throws Exception {
-        // given
-        UUID postId = UUID.fromString("1234a9a9-90b6-9898-a9dc-92c9861aa98c"); // UUID ver7
+	@Test
+	@DisplayName("게시글 단건 조회 성공")
+	@Sql("classpath:sql/post-for-get.sql")
+	void 게시글_단건_조회_성공() throws Exception {
+		// given
+		final String accessToken = createUserAccessToken();
 
-        // when
-        final ResultActions result = mockMvc.perform(
-            get("/api/posts/{postId}", postId) // HTTP method (URL)
-                .contentType(MediaType.APPLICATION_JSON));
+		UUID postId = UUID.fromString("1234a9a9-90b6-9898-a9dc-92c9861aa98c"); // UUID ver7
 
-        // then
-        result.andExpectAll(
-                status().isOk(),
-                jsonPath("$.result").value(ResultType.SUCCESS.name()),
-                jsonPath("$.data").exists(),
-                jsonPath("$.error").doesNotExist())
-            .andDo(document("post-get-success", postGetSuccessResource()));
-    }
+		// when
+		final ResultActions result = mockMvc.perform(
+			get("/api/posts/{postId}", postId) // HTTP method (URL)
+				.contentType(MediaType.APPLICATION_JSON)
+				.header(HttpHeaders.AUTHORIZATION, toBearerAuthorizationHeader(accessToken)));
 
-    private ResourceSnippet postGetSuccessResource() {
-        return resource(
-            ResourceSnippetParameters.builder()
-                .tag("Post API")
-                .summary("게시글 단건 조회 API")
-                .description("게시글 ID로 조회를 한다.")
-                .requestHeaders(
-                    headerWithName(HttpHeaders.CONTENT_TYPE).description("컨텐츠 타입"))
-                .responseFields(
-                    fieldWithPath("result").type(JsonFieldType.STRING).description("응답 결과"),
-                    fieldWithPath("data.postId").type(JsonFieldType.STRING).description("게시글 아이디"),
-                    fieldWithPath("data.title").type(JsonFieldType.STRING).description("게시글 제목"),
-                    fieldWithPath("data.content").type(JsonFieldType.STRING).description("게시글 내용"),
-                    fieldWithPath("data.companyName").type(JsonFieldType.STRING).description("회사 이름"),
-                    fieldWithPath("data.authorName").type(JsonFieldType.STRING).description("작성자"),
-                    fieldWithPath("data.approval").type(JsonFieldType.STRING).description("승인여부"),
-                    fieldWithPath("error").type(JsonFieldType.NULL).description("에러 정보"))
-                .build()
-        );
-    }    
-   
+		// then
+		result.andExpectAll(
+				status().isOk(),
+				jsonPath("$.result").value(ResultType.SUCCESS.name()),
+				jsonPath("$.data").exists(),
+				jsonPath("$.error").doesNotExist())
+			.andDo(document("post-get-success", postGetSuccessResource()));
+	}
+
+	private ResourceSnippet postGetSuccessResource() {
+		return resource(
+			ResourceSnippetParameters.builder()
+				.tag("Post API")
+				.summary("게시글 단건 조회 API")
+				.description("게시글 ID로 조회를 한다.")
+				.requestHeaders(
+					headerWithName(HttpHeaders.CONTENT_TYPE).description("컨텐츠 타입"),
+					headerWithName(HttpHeaders.AUTHORIZATION).description("엑세스 토큰")
+				)
+				.responseFields(
+					fieldWithPath("result").type(JsonFieldType.STRING).description("응답 결과"),
+					fieldWithPath("data.postId").type(JsonFieldType.STRING).description("게시글 아이디"),
+					fieldWithPath("data.title").type(JsonFieldType.STRING).description("게시글 제목"),
+					fieldWithPath("data.content").type(JsonFieldType.STRING).description("게시글 내용"),
+					fieldWithPath("data.companyName").type(JsonFieldType.STRING).description("회사 이름"),
+					fieldWithPath("data.authorName").type(JsonFieldType.STRING).description("작성자"),
+					fieldWithPath("data.approval").type(JsonFieldType.STRING).description("승인여부"),
+					fieldWithPath("error").type(JsonFieldType.NULL).description("에러 정보"))
+				.build()
+		);
+	}
+
 	@Test
 	@DisplayName("게시글 삭제 성공")
 	@Sql("classpath:sql/post-for-delete.sql")
 	void 게시글_삭제_성공() throws Exception {
 		// given
+		final String accessToken = createUserAccessToken();
+
 		UUID postId = UUID.fromString("1234a9a9-90b6-9898-a9dc-92c9861aa98c"); // UUID ver7
 
 		// when
 		final ResultActions result = mockMvc.perform(
 			delete("/api/posts/{postId}", postId) // HTTP method (URL)
-				.contentType(MediaType.APPLICATION_JSON));
+				.contentType(MediaType.APPLICATION_JSON)
+				.header(HttpHeaders.AUTHORIZATION, toBearerAuthorizationHeader(accessToken)));
 
 		// then
 		result.andExpectAll(
@@ -288,7 +295,8 @@ public class PostDocumentationTest extends RestDocsDocumentation {
 				.summary("게시글 삭제 API")
 				.description("게시글을 삭제한다.")
 				.requestHeaders(
-					headerWithName(HttpHeaders.CONTENT_TYPE).description("컨텐츠 타입"))
+					headerWithName(HttpHeaders.CONTENT_TYPE).description("컨텐츠 타입"),
+					headerWithName(HttpHeaders.AUTHORIZATION).description("엑세스 토큰"))
 				.responseFields(
 					fieldWithPath("result").type(JsonFieldType.STRING).description("응답 결과"),
 					fieldWithPath("data.postId").type(JsonFieldType.STRING).description("수정한 게시글 아이디"),
@@ -296,19 +304,22 @@ public class PostDocumentationTest extends RestDocsDocumentation {
 				.build()
 		);
 	}
-        
+
 	@Test
 	@DisplayName("게시글 목록 조회 성공")
 	@Sql("classpath:sql/post-for-get-list.sql")
 	void 게시글_목록_조회_성공() throws Exception {
 		// given
+		final String accessToken = createUserAccessToken();
+
 		UUID projectStepId = UUID.fromString("019739d2-2e80-709f-a9c5-7da758c956d1");
 
 		// when
 		final ResultActions result = mockMvc.perform(
 			get("/api/posts?page={page}&projectStepId={projectStepId}&keyword={keyword}&deleted={deleted}",
 				1, projectStepId, null, null) // HTTP method (URL)
-				.contentType(MediaType.APPLICATION_JSON));
+				.contentType(MediaType.APPLICATION_JSON)
+				.header(HttpHeaders.AUTHORIZATION, toBearerAuthorizationHeader(accessToken)));
 
 		// then
 		result.andExpectAll(
@@ -326,13 +337,13 @@ public class PostDocumentationTest extends RestDocsDocumentation {
 				.summary("게시글 목록 조회 API")
 				.description("게시글 목록을 검색조건에 따라 조회를 한다.")
 				.requestHeaders(
-					headerWithName(HttpHeaders.CONTENT_TYPE).description("컨텐츠 타입"))
+					headerWithName(HttpHeaders.CONTENT_TYPE).description("컨텐츠 타입"),
+					headerWithName(HttpHeaders.AUTHORIZATION).description("엑세스 토큰"))
 				.queryParameters(
 					parameterWithName("page").description("페이지 번호"),
 					parameterWithName("projectStepId").description("프로젝트 단계 ID").optional(),
 					parameterWithName("keyword").description("검색어").optional(),
-					parameterWithName("deleted").description("삭제 여부").optional()
-				)
+					parameterWithName("deleted").description("삭제 여부").optional())
 				.responseFields(
 					fieldWithPath("result").type(JsonFieldType.STRING).description("응답 결과"),
 					fieldWithPath("data.posts.[].postId").type(JsonFieldType.STRING).description("게시글 아이디"),

--- a/src/test/java/kr/mywork/docs/ProjectDocumentationTest.java
+++ b/src/test/java/kr/mywork/docs/ProjectDocumentationTest.java
@@ -30,15 +30,18 @@ public class ProjectDocumentationTest extends RestDocsDocumentation {
 	@Sql("classpath:sql/project-for-member-list.sql")
 	void 프로젝트_할당_멤버_조회_성공() throws Exception {
 		//given
+		final String accessToken = createDevAdminAccessToken();
+
 		final UUID projectId = UUID.fromString("d73b1f10-47e2-7a2d-c1e5-f17125d62999");
-		final UUID compnayId = UUID.fromString("a62a0c20-91e2-7c2d-b0e5-e16115c61888");
+		final UUID companyId = UUID.fromString("a62a0c20-91e2-7c2d-b0e5-e16115c61888");
 
 		//when
 		final ResultActions result = mockMvc.perform(
 			get("/api/projects/members")
 				.param("projectId", projectId.toString())
-				.param("companyId", compnayId.toString())
-				.contentType(MediaType.APPLICATION_JSON));
+				.param("companyId", companyId.toString())
+				.contentType(MediaType.APPLICATION_JSON)
+				.header(HttpHeaders.AUTHORIZATION, toBearerAuthorizationHeader(accessToken)));
 
 		//then
 		result.andExpectAll(
@@ -56,7 +59,8 @@ public class ProjectDocumentationTest extends RestDocsDocumentation {
 				.summary("프로젝트 할당할 멤버 조회 API")
 				.description("프로젝트 멤버를 조회한다")
 				.requestHeaders(
-					headerWithName(HttpHeaders.CONTENT_TYPE).description("컨텐츠 타입"))
+					headerWithName(HttpHeaders.CONTENT_TYPE).description("컨텐츠 타입"),
+					headerWithName(HttpHeaders.AUTHORIZATION).description("엑세스 토큰"))
 				.responseFields(
 					fieldWithPath("result").type(JsonFieldType.STRING).description("응답 결과"),
 					fieldWithPath("data.members[].memberId").type(JsonFieldType.STRING)

--- a/src/test/java/kr/mywork/docs/ProjectStepDocumentationTest.java
+++ b/src/test/java/kr/mywork/docs/ProjectStepDocumentationTest.java
@@ -143,12 +143,15 @@ public class ProjectStepDocumentationTest extends RestDocsDocumentation {
 	@Sql("classpath:sql/project-step-get.sql")
 	void 프로젝트_단계_조회_성공() throws Exception {
 		//given
+		final String accessToken = createUserAccessToken();
+
 		UUID projectId = UUID.fromString("0196f7a6-10b6-7123-a2dc-32c3861ea55e");
 
 		// when
 		final ResultActions result = mockMvc.perform(
 			get("/api/projects/{projectId}/steps", projectId)
-				.contentType(MediaType.APPLICATION_JSON));
+				.contentType(MediaType.APPLICATION_JSON)
+				.header(HttpHeaders.AUTHORIZATION, toBearerAuthorizationHeader(accessToken)));
 
 		//then
 		result.andExpectAll(
@@ -166,7 +169,8 @@ public class ProjectStepDocumentationTest extends RestDocsDocumentation {
 				.summary("프로젝트 단계 조회 API")
 				.description("프로젝트 단계를 조회한다")
 				.requestHeaders(
-					headerWithName(HttpHeaders.CONTENT_TYPE).description("컨텐츠 타입"))
+					headerWithName(HttpHeaders.CONTENT_TYPE).description("컨텐츠 타입"),
+					headerWithName(HttpHeaders.AUTHORIZATION).description("엑세스 토큰"))
 				.responseFields(
 					fieldWithPath("result").type(JsonFieldType.STRING).description("응답 결과"),
 					fieldWithPath("data.steps[].projectStepId").type(JsonFieldType.STRING)

--- a/src/test/java/kr/mywork/docs/RestDocsDocumentation.java
+++ b/src/test/java/kr/mywork/docs/RestDocsDocumentation.java
@@ -70,28 +70,28 @@ abstract class RestDocsDocumentation {
 		return this.jwtTokenProvider.createAccessToken(
 			UUID.fromString("019739ed-f977-7c85-9138-7c8c0e2721d6"),
 			"user01@example.com",
-			MemberRole.USER.getRoleName());
+			MemberRole.USER.getRoleName(), "유저 이름");
 	}
 
 	public String createClientAdminAccessToken() {
 		return this.jwtTokenProvider.createAccessToken(
 			UUID.fromString("019739ec-b50a-7f17-b375-3740a1bffcf1"),
 			"client_admin@example.com",
-			MemberRole.CLIENT_ADMIN.getRoleName());
+			MemberRole.CLIENT_ADMIN.getRoleName(), "클라이언트 어드민 이름");
 	}
 
 	public String createDevAdminAccessToken() {
 		return this.jwtTokenProvider.createAccessToken(
 			UUID.fromString("019739ea-e7eb-76b7-b5e1-b9dc3ea1e9c2"),
 			"dev_admin@example.com",
-			MemberRole.DEV_ADMIN.getRoleName());
+			MemberRole.DEV_ADMIN.getRoleName(), "개발사 어드민 이름");
 	}
 
 	public String createSystemAccessToken() {
 		return this.jwtTokenProvider.createAccessToken(
 			UUID.fromString("0196f7a6-10b6-7123-a2dc-32c3861ea55e"),
 			"system_admin@example.com",
-			MemberRole.SYSTEM_ADMIN.getRoleName());
+			MemberRole.SYSTEM_ADMIN.getRoleName(), "시스템 어드민 이름");
 	}
 
 	public String toBearerAuthorizationHeader(final String accessToken) {

--- a/src/test/java/kr/mywork/infrastructure/company/rdb/QueryDslCompanyRepositoryTest.java
+++ b/src/test/java/kr/mywork/infrastructure/company/rdb/QueryDslCompanyRepositoryTest.java
@@ -12,7 +12,6 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.jdbc.Sql;
 
 import kr.mywork.base.annotations.RdbRepositoryTest;
@@ -30,7 +29,6 @@ class QueryDslCompanyRepositoryTest {
 	@Test
 	@DisplayName("기본 회사 목록 조회 성공")
 	@Sql("classpath:sql/company-list.sql")
-	@WithMockUser(roles = "SYSTEM_ADMIN")
 	void 기본_회사_목록_조회_성공() {
 		// given
 		int companyPageSize = 10;
@@ -50,7 +48,6 @@ class QueryDslCompanyRepositoryTest {
 	@Test
 	@DisplayName("회사 활성화 목록 조회 성공")
 	@Sql("classpath:sql/company-list.sql")
-	@WithMockUser(roles = "SYSTEM_ADMIN")
 	void 회사_활성화_목록_조회_성공() {
 		// given
 		String companyType = "DEV";
@@ -73,7 +70,6 @@ class QueryDslCompanyRepositoryTest {
 	@Test
 	@DisplayName("회사 검색어 목록 조회 성공 - 키워드 앞부분 일치")
 	@Sql("classpath:sql/company-list.sql")
-	@WithMockUser(roles = "SYSTEM_ADMIN")
 	void 회사_검색어_목록_조회_성공() {
 		// given
 		String companyType = "DEV";
@@ -94,7 +90,6 @@ class QueryDslCompanyRepositoryTest {
 	@ParameterizedTest
 	@MethodSource("companyListMethodSource")
 	@Sql("classpath:sql/company-list.sql")
-	@WithMockUser(roles = "SYSTEM_ADMIN")
 	void 회사_검색어_목록_갯수_조회_성공(final String companyType, final String keyword, final Boolean deleted, final Long expected) {
 		// given, when
 		final Long totalCount = companyRepository.countTotalCompaniesByCondition(companyType, keyword, deleted);

--- a/src/test/java/kr/mywork/interfaces/post/controller/ReviewControllerTest.java
+++ b/src/test/java/kr/mywork/interfaces/post/controller/ReviewControllerTest.java
@@ -23,7 +23,6 @@ import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.FilterType;
 import org.springframework.http.MediaType;
-
 import org.springframework.security.config.annotation.web.WebSecurityConfigurer;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
@@ -54,7 +53,6 @@ class ReviewControllerTest {
 
 	@Test
 	@DisplayName("리뷰 생성 요청 성공")
-	@WithMockUser(roles = "SYSTEM_ADMIN")
 	void 리뷰_생성_요청_성공() throws Exception {
 		// given
 		final UUID postId = UUID.fromString("01972f9b-232a-7dbe-aad2-3bffc0b78ced");
@@ -83,7 +81,6 @@ class ReviewControllerTest {
 
 	@Test
 	@DisplayName("리뷰 생성 요청 입력 값 실패 (빈 코멘트)")
-	@WithMockUser(roles = "SYSTEM_ADMIN")
 	void 리뷰_생성_요청_입력_값_실패() throws Exception {
 		// given
 		final UUID postId = UUID.fromString("01972f9b-232a-7dbe-aad2-3bffc0b78ced");

--- a/src/test/java/kr/mywork/interfaces/project_step/controller/ProjectStepControllerTest.java
+++ b/src/test/java/kr/mywork/interfaces/project_step/controller/ProjectStepControllerTest.java
@@ -24,7 +24,6 @@ import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.FilterType;
 import org.springframework.http.MediaType;
-
 import org.springframework.security.config.annotation.web.WebSecurityConfigurer;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
@@ -56,7 +55,6 @@ class ProjectStepControllerTest {
 
 	@Test
 	@DisplayName("프로젝트 단계 목록 생성 성공")
-	@WithMockUser(roles = "SYSTEM_ADMIN")
 	void 프로젝트_단계_목록_생성_성공() throws Exception {
 		// given
 		when(projectStepService.saveAll(any(), any())).thenReturn(7);
@@ -90,7 +88,6 @@ class ProjectStepControllerTest {
 	@ParameterizedTest
 	@MethodSource("projectStepFailMethodSource")
 	@DisplayName("프로젝트 단계 목록 유효하지 않은 입력값 실패")
-	@WithMockUser(roles = "SYSTEM_ADMIN")
 	void 프로젝트_단계_목록_유효하지_않은_입력값_실패(
 		final UUID projectId, final List<ProjectStepCreateWebRequest> projectStepCreateWebRequests) throws Exception {
 		// given
@@ -135,7 +132,6 @@ class ProjectStepControllerTest {
 	@ParameterizedTest
 	@MethodSource("projectStepUpdateFileMethodSource")
 	@DisplayName("프로젝트 단계 수정 유효하지 않은 입력값 실패")
-	@WithMockUser(roles = "SYSTEM_ADMIN")
 	void 프로젝트_단계_수정_유효하지_않은_입력값_실패(
 		final UUID projectId, final List<ProjectStepUpdateWebRequest> projectStepUpdateWebRequests) throws Exception {
 		// given


### PR DESCRIPTION
## 📌 개요

- spring security 추가로 인한 테스트 빌드 실패 이슈

## 🛠️ 변경 사항

- @WithMockUser 제거
- AccessToken payload 로 이름 필드 추가
- 통합 테스트 AccessToken 추가 및 검증 확인

## ✅ 주요 체크 포인트

- [ ] RestDocsDocumentation 내부에 access token 생성 로직 추가

## 🔁 테스트 결과

![image](https://github.com/user-attachments/assets/f5f3d58b-91cd-438b-87d9-dfe98b8a787b)


## 🔗 연관된 이슈

- #83 
