### PR TITLE
프로젝트 할당 멤버 조회 누락파일 추가

### DIFF
--- a/src/main/java/kr/mywork/domain/project/service/ProjectService.java
+++ b/src/main/java/kr/mywork/domain/project/service/ProjectService.java
@@ -2,19 +2,23 @@ package kr.mywork.domain.project.service;
 
 import java.util.List;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import kr.mywork.domain.member.model.Member;
+import kr.mywork.domain.member.repository.MemberRepository;
 import kr.mywork.domain.project.errors.ProjectErrorType;
 import kr.mywork.domain.project.errors.ProjectNotFoundException;
+import kr.mywork.domain.project.repository.ProjectRepository;
 import kr.mywork.domain.project.service.dto.request.ProjectCreateRequest;
 import kr.mywork.domain.project.service.dto.request.ProjectUpdateRequest;
+import kr.mywork.domain.project.service.dto.response.ProjectMemberResponse;
 import kr.mywork.domain.project.service.dto.response.ProjectSelectResponse;
 import kr.mywork.domain.project.service.dto.response.ProjectSelectWithAssignResponse;
 import kr.mywork.domain.project.service.dto.response.ProjectUpdateResponse;
-import kr.mywork.domain.project.repository.ProjectRepository;
 import lombok.RequiredArgsConstructor;
 
 @Service
@@ -25,6 +29,7 @@ public class ProjectService {
 	private int projectPageSize;
 
 	private final ProjectRepository projectRepository;
+	private final MemberRepository memberRepository;
 
 	@Transactional
 	public UUID createProject(ProjectCreateRequest request) {
@@ -80,5 +85,17 @@ public class ProjectService {
 		final Boolean deleted
 	) {
 		return projectRepository.countTotalProjectsByCondition(memberId, nameKeyword, deleted);
+	}
+
+	@Transactional
+	public List<ProjectMemberResponse> findMemberByCompanyId(UUID companyId ,UUID projectId) {
+
+		List<Member> companyMembers = memberRepository.findMemberListByCompanyId(companyId,projectId);
+
+		return companyMembers.stream()
+			.map(member -> new ProjectMemberResponse(
+				member.getId(),
+				member.getName()
+			)).collect(Collectors.toList());
 	}
 }

--- a/src/main/java/kr/mywork/interfaces/project/controller/ProjectController.java
+++ b/src/main/java/kr/mywork/interfaces/project/controller/ProjectController.java
@@ -13,6 +13,7 @@ import kr.mywork.common.api.support.response.ApiResponse;
 import kr.mywork.domain.project.service.ProjectService;
 import kr.mywork.domain.project.service.dto.request.ProjectCreateRequest;
 import kr.mywork.domain.project.service.dto.request.ProjectUpdateRequest;
+import kr.mywork.domain.project.service.dto.response.ProjectMemberResponse;
 import kr.mywork.domain.project.service.dto.response.ProjectSelectResponse;
 import kr.mywork.domain.project.service.dto.response.ProjectSelectWithAssignResponse;
 import kr.mywork.domain.project.service.dto.response.ProjectUpdateResponse;
@@ -25,6 +26,7 @@ import kr.mywork.interfaces.project.controller.dto.response.ProjectDetailWebResp
 import kr.mywork.interfaces.project.controller.dto.response.ProjectListWebResponse;
 import kr.mywork.interfaces.project.controller.dto.response.ProjectSelectWebResponse;
 import kr.mywork.interfaces.project.controller.dto.response.ProjectUpdateWebResponse;
+import kr.mywork.interfaces.project.dto.response.ProjectMemberListWebResponse;
 import lombok.RequiredArgsConstructor;
 
 @RestController
@@ -104,5 +106,18 @@ public class ProjectController {
 		long totalCount = projectService.countTotalProjectsByCondition(memberId, nameKeyword, deleted);
 
 		return ApiResponse.success(new ProjectListWebResponse(webList, totalCount));
+	}
+
+	@GetMapping("/members")
+	public ApiResponse<ProjectMemberListWebResponse> projectMemberListWebResponseApiResponse(
+		@RequestParam(name = "companyId") UUID companyId,
+		@RequestParam(name = "projectId") UUID projectId
+	) {
+		List<ProjectMemberResponse> projectMemberResponses = projectService.findMemberByCompanyId(companyId, projectId);
+
+		ProjectMemberListWebResponse projectMemberListWebResponse = ProjectMemberListWebResponse.from(
+			projectMemberResponses);
+
+		return ApiResponse.success(projectMemberListWebResponse);
 	}
 }

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -18,6 +18,9 @@ member:
 post:
   page:
     size: 10
+project:
+  page:
+    size: 10
 jwt:
   access-token:
     private-key: 126cab8a5d9087a27be4e2a0599682e2bab38e80201d1befa2dd9d55ecbdeac58bab0c84301ad9f9f8a71836825e5a7214e7a9fb17a8578418de6cfe9a15cbc7


### PR DESCRIPTION
## 📌 개요

프로젝트 할당 멤버 조회 누락파일 추가

## 🛠️ 변경 사항
누락되엇던 파일 3가지 추가

## ✅ 주요 체크 포인트


- [ ]  프로젝트 할당 가능 멤버 조회
- [ ] 통합 테스트

## 🔁 테스트 결과
![image](https://github.com/user-attachments/assets/cb5a2a6b-4d5b-4a11-b45f-c3f6611cb342)

## 🔗 연관된 이슈
#72 
