### PR TITLE
[feat] 프로젝트 멤버 할당 API

### DIFF
--- a/src/main/java/kr/mywork/domain/project/model/ProjectMember.java
+++ b/src/main/java/kr/mywork/domain/project/model/ProjectMember.java
@@ -11,10 +11,12 @@ import jakarta.persistence.Id;
 
 import kr.mywork.common.rdb.id.UnixTimeOrderedUuidGeneratedValue;
 import lombok.AccessLevel;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
 public class ProjectMember {
 
 	@Id
@@ -24,6 +26,7 @@ public class ProjectMember {
 	@Column(name = "project_id", nullable = false, columnDefinition = "BINARY(16)")
 	private UUID projectId;
 
+	@Getter
 	@Column(name = "member_id", nullable = false, columnDefinition = "BINARY(16)")
 	private UUID memberId;
 
@@ -36,4 +39,13 @@ public class ProjectMember {
 	@Column(name = "created_at", nullable = false, columnDefinition = "timestamp")
 	@CreationTimestamp
 	private LocalDateTime createdAt;
+
+
+	public ProjectMember(UUID projectId, UUID memberId) {
+		this.projectId = projectId;
+		this.memberId = memberId;
+		this.manager = false;
+		this.deleted = false;
+		this.createdAt = LocalDateTime.now();
+	}
 }

--- a/src/main/java/kr/mywork/domain/project_member/repository/ProjectMemberRepository.java
+++ b/src/main/java/kr/mywork/domain/project_member/repository/ProjectMemberRepository.java
@@ -1,0 +1,7 @@
+package kr.mywork.domain.project_member.repository;
+
+import kr.mywork.domain.project.model.ProjectMember;
+
+public interface ProjectMemberRepository {
+	ProjectMember save(ProjectMember projectMember);
+}

--- a/src/main/java/kr/mywork/domain/project_member/service/ProjectMemberService.java
+++ b/src/main/java/kr/mywork/domain/project_member/service/ProjectMemberService.java
@@ -1,0 +1,27 @@
+package kr.mywork.domain.project_member.service;
+
+import java.util.UUID;
+
+import org.springframework.stereotype.Service;
+
+import jakarta.transaction.Transactional;
+import kr.mywork.domain.project.model.ProjectMember;
+import kr.mywork.domain.project_member.repository.ProjectMemberRepository;
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class ProjectMemberService {
+
+	final ProjectMemberRepository projectMemberRepository;
+
+	@Transactional
+	public UUID addMemberToCompany(UUID projectId, UUID memberId) {
+
+		ProjectMember projectMember = new ProjectMember(projectId,memberId);
+
+		final ProjectMember savedMember = projectMemberRepository.save(projectMember);
+
+		return savedMember.getMemberId();
+	}
+}

--- a/src/main/java/kr/mywork/infrastructure/project_member/rdb/JpaProjectMemberRepository.java
+++ b/src/main/java/kr/mywork/infrastructure/project_member/rdb/JpaProjectMemberRepository.java
@@ -1,0 +1,10 @@
+package kr.mywork.infrastructure.project_member.rdb;
+
+import java.util.UUID;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import kr.mywork.domain.project.model.ProjectMember;
+
+public interface JpaProjectMemberRepository extends JpaRepository<ProjectMember, UUID> {
+}

--- a/src/main/java/kr/mywork/infrastructure/project_member/rdb/QueryDslProjectMemberRepository.java
+++ b/src/main/java/kr/mywork/infrastructure/project_member/rdb/QueryDslProjectMemberRepository.java
@@ -1,0 +1,19 @@
+package kr.mywork.infrastructure.project_member.rdb;
+
+import org.springframework.stereotype.Repository;
+
+import kr.mywork.domain.project.model.ProjectMember;
+import kr.mywork.domain.project_member.repository.ProjectMemberRepository;
+import lombok.RequiredArgsConstructor;
+
+@Repository
+@RequiredArgsConstructor
+public class QueryDslProjectMemberRepository implements ProjectMemberRepository {
+
+	final JpaProjectMemberRepository jpaProjectMemberRepository;
+
+	@Override
+	public ProjectMember save(ProjectMember projectMember) {
+		return jpaProjectMemberRepository.save(projectMember);
+	}
+}

--- a/src/main/java/kr/mywork/interfaces/project_member/controller/ProjectMemberController.java
+++ b/src/main/java/kr/mywork/interfaces/project_member/controller/ProjectMemberController.java
@@ -1,0 +1,35 @@
+package kr.mywork.interfaces.project_member.controller;
+
+import java.util.UUID;
+
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import kr.mywork.common.api.support.response.ApiResponse;
+import kr.mywork.domain.project_member.service.ProjectMemberService;
+import kr.mywork.interfaces.project_member.controller.dto.response.ProjectMemberAddWebResponse;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("/api/project-member")
+@RequiredArgsConstructor
+public class ProjectMemberController {
+
+	final ProjectMemberService projectMemberService;
+
+	@PostMapping("/member")
+	public ApiResponse<ProjectMemberAddWebResponse> projectMemberAddWebResponseApiResponse(
+		@RequestParam(name="projectId") UUID projectId,
+		@RequestParam(name="memberId") UUID memberId
+	) {
+
+		final UUID addedMemberId = projectMemberService.addMemberToCompany(projectId,memberId);
+
+		final ProjectMemberAddWebResponse projectMemberAddWebResponse = new ProjectMemberAddWebResponse(addedMemberId);
+
+		return ApiResponse.success(projectMemberAddWebResponse);
+	}
+}
+

--- a/src/main/java/kr/mywork/interfaces/project_member/controller/dto/response/ProjectMemberAddWebResponse.java
+++ b/src/main/java/kr/mywork/interfaces/project_member/controller/dto/response/ProjectMemberAddWebResponse.java
@@ -1,0 +1,6 @@
+package kr.mywork.interfaces.project_member.controller.dto.response;
+
+import java.util.UUID;
+
+public record ProjectMemberAddWebResponse(UUID memberId) {
+}

--- a/src/test/java/kr/mywork/docs/ProjectMemberDocumentationTest.java
+++ b/src/test/java/kr/mywork/docs/ProjectMemberDocumentationTest.java
@@ -1,0 +1,69 @@
+package kr.mywork.docs;
+
+import static com.epages.restdocs.apispec.MockMvcRestDocumentationWrapper.document;
+import static com.epages.restdocs.apispec.ResourceDocumentation.headerWithName;
+import static com.epages.restdocs.apispec.ResourceDocumentation.resource;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.util.UUID;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.restdocs.payload.JsonFieldType;
+import org.springframework.test.web.servlet.ResultActions;
+
+import com.epages.restdocs.apispec.ResourceSnippet;
+import com.epages.restdocs.apispec.ResourceSnippetParameters;
+
+import kr.mywork.common.api.support.response.ResultType;
+
+public class ProjectMemberDocumentationTest extends RestDocsDocumentation {
+
+	@Test
+	@DisplayName("프로젝트 맴버 할당 성공")
+	void 프로젝트_멤버_할당_성공() throws Exception {
+		// given
+		// TODO Project 생성 API 개발 후, ProjectId 생성 및 검증 샘플 데이터 추가 필요
+		final String accessToken = createDevAdminAccessToken();
+
+		final UUID projectId = UUID.fromString("0197207e-7331-7000-946b-a29a79a82424");
+		final UUID memberId = UUID.fromString("0ddcc36d-193e-41f4-b48e-8b77d5d19162");
+
+		// when
+		final ResultActions result = mockMvc.perform(post("/api/project-member/member")
+				.param("projectId", projectId.toString())
+				.param("memberId", memberId.toString())
+			.header(HttpHeaders.AUTHORIZATION, toBearerAuthorizationHeader(accessToken))
+			.contentType(MediaType.APPLICATION_JSON));
+
+		// then
+		result.andExpectAll(
+				status().isOk(),
+				jsonPath("$.result").value(ResultType.SUCCESS.name()),
+				jsonPath("$.data").exists(),
+				jsonPath("$.error").doesNotExist())
+			.andDo(document("project-id-create-success", projectIdCreateSuccessResource()));
+	}
+
+	private ResourceSnippet projectIdCreateSuccessResource() {
+		return resource(
+			ResourceSnippetParameters.builder()
+				.tag("Project Member API")
+				.summary("프로젝트 멤버 할당 API")
+				.description("프로젝트 멤버를 할당한다")
+				.requestHeaders(
+					headerWithName(HttpHeaders.CONTENT_TYPE).description("컨텐츠 타입"),
+					headerWithName(HttpHeaders.AUTHORIZATION).description("엑세스 토큰"))
+				.responseFields(
+					fieldWithPath("result").type(JsonFieldType.STRING).description("응답 결과"),
+					fieldWithPath("data.memberId").type(JsonFieldType.STRING).description("할당한 멤버의 ID"),
+					fieldWithPath("error").type(JsonFieldType.NULL).description("에러 정보"))
+				.build());
+	}
+
+}


### PR DESCRIPTION
## 📌 개요
프로젝트 멤버 할당 API

## 🛠️ 변경 사항
- 프로젝트 멤버를 할당합니다.

## ✅ 주요 체크 포인트

- [ ] 프로젝트 멤버 테이블에 추가
- [ ] 통합 테스트

## 🔁 테스트 결과
<img width="1294" alt="image" src="https://github.com/user-attachments/assets/cbc5d482-5095-41e3-8239-216bfedde82c" />

##  🔗 연관된 이슈
#72 