### PR TITLE
체크리스트 상세조회 API

### DIFF
--- a/src/main/java/kr/mywork/domain/project_checklist/errors/ProjectCheckListErrorCode.java
+++ b/src/main/java/kr/mywork/domain/project_checklist/errors/ProjectCheckListErrorCode.java
@@ -1,0 +1,5 @@
+package kr.mywork.domain.project_checklist.errors;
+
+public enum ProjectCheckListErrorCode {
+	ERROR_PROJECT_CHECK_LIST01
+}

--- a/src/main/java/kr/mywork/domain/project_checklist/errors/ProjectCheckListErrorType.java
+++ b/src/main/java/kr/mywork/domain/project_checklist/errors/ProjectCheckListErrorType.java
@@ -1,0 +1,13 @@
+package kr.mywork.domain.project_checklist.errors;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum ProjectCheckListErrorType {
+	PROJECT_CHECK_LIST_NOT_FOUND(ProjectCheckListErrorCode.ERROR_PROJECT_CHECK_LIST01, "체크리스트를 찾을 수 없습니다.");
+
+	private final ProjectCheckListErrorCode errorCode;
+	private final String message;
+}

--- a/src/main/java/kr/mywork/domain/project_checklist/errors/ProjectCheckListException.java
+++ b/src/main/java/kr/mywork/domain/project_checklist/errors/ProjectCheckListException.java
@@ -1,0 +1,13 @@
+package kr.mywork.domain.project_checklist.errors;
+
+import lombok.Getter;
+
+@Getter
+public abstract class ProjectCheckListException extends RuntimeException {
+	private final ProjectCheckListErrorType errorType;
+
+	public ProjectCheckListException(final ProjectCheckListErrorType errorType) {
+		super(errorType.getMessage());
+		this.errorType = errorType;
+	}
+}

--- a/src/main/java/kr/mywork/domain/project_checklist/errors/ProjectCheckListNotFoundException.java
+++ b/src/main/java/kr/mywork/domain/project_checklist/errors/ProjectCheckListNotFoundException.java
@@ -1,0 +1,7 @@
+package kr.mywork.domain.project_checklist.errors;
+
+public class ProjectCheckListNotFoundException extends ProjectCheckListException {
+	public ProjectCheckListNotFoundException(ProjectCheckListErrorType errorType) {
+		super(errorType);
+	}
+}

--- a/src/main/java/kr/mywork/domain/project_checklist/model/ProjectCheckList.java
+++ b/src/main/java/kr/mywork/domain/project_checklist/model/ProjectCheckList.java
@@ -1,6 +1,9 @@
 package kr.mywork.domain.project_checklist.model;
 
+import java.time.LocalDateTime;
 import java.util.UUID;
+
+import org.hibernate.annotations.CreationTimestamp;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -33,10 +36,13 @@ public class ProjectCheckList {
 	private UUID projectStepId;
 
 	@Column(nullable = false)
-	private Boolean approval;
+	private String approval;
+
+	@CreationTimestamp
+	private LocalDateTime createdAt;
 
 	public ProjectCheckList(String title, UUID devCompanyId, UUID clientCompanyId,
-		UUID projectStepId, Boolean approval) {
+		UUID projectStepId, String approval) {
 		this.title = title;
 		this.devCompanyId = devCompanyId;
 		this.clientCompanyId = clientCompanyId;

--- a/src/main/java/kr/mywork/domain/project_checklist/repository/ProjectCheckListRepository.java
+++ b/src/main/java/kr/mywork/domain/project_checklist/repository/ProjectCheckListRepository.java
@@ -1,8 +1,13 @@
 package kr.mywork.domain.project_checklist.repository;
 
+import java.util.Optional;
+import java.util.UUID;
+
 import kr.mywork.domain.project_checklist.model.ProjectCheckList;
 import kr.mywork.domain.project_checklist.service.dto.request.ProjectCheckListCreateRequest;
 
 public interface ProjectCheckListRepository {
 	ProjectCheckList save(ProjectCheckListCreateRequest projectCheckListRequest);
+
+	Optional<ProjectCheckList> findById(UUID checkListId);
 }

--- a/src/main/java/kr/mywork/domain/project_checklist/service/ProjectCheckListService.java
+++ b/src/main/java/kr/mywork/domain/project_checklist/service/ProjectCheckListService.java
@@ -1,5 +1,7 @@
 package kr.mywork.domain.project_checklist.service;
 
+import java.util.UUID;
+
 import org.springframework.stereotype.Service;
 
 import jakarta.transaction.Transactional;
@@ -7,10 +9,13 @@ import kr.mywork.domain.company.errors.CompanyErrorType;
 import kr.mywork.domain.company.errors.CompanyNotFoundException;
 import kr.mywork.domain.company.model.CompanyType;
 import kr.mywork.domain.company.repository.CompanyRepository;
+import kr.mywork.domain.project_checklist.errors.ProjectCheckListErrorType;
+import kr.mywork.domain.project_checklist.errors.ProjectCheckListNotFoundException;
 import kr.mywork.domain.project_checklist.model.ProjectCheckList;
 import kr.mywork.domain.project_checklist.repository.ProjectCheckListRepository;
 import kr.mywork.domain.project_checklist.service.dto.request.ProjectCheckListCreateRequest;
 import kr.mywork.domain.project_checklist.service.dto.response.ProjectCheckListCreateResponse;
+import kr.mywork.domain.project_checklist.service.dto.response.ProjectCheckListDetailResponse;
 import kr.mywork.domain.project_step.repository.ProjectStepRepository;
 import lombok.RequiredArgsConstructor;
 
@@ -40,4 +45,11 @@ public class ProjectCheckListService {
 
 	}
 
+	public ProjectCheckListDetailResponse getProjectCheckList(UUID checkListId) {
+		ProjectCheckList projectCheckList = projectCheckListRepository.findById(checkListId)
+			.orElseThrow(
+				() -> new ProjectCheckListNotFoundException(ProjectCheckListErrorType.PROJECT_CHECK_LIST_NOT_FOUND));
+
+		return new ProjectCheckListDetailResponse(projectCheckList);
+	}
 }

--- a/src/main/java/kr/mywork/domain/project_checklist/service/dto/request/ProjectCheckListCreateRequest.java
+++ b/src/main/java/kr/mywork/domain/project_checklist/service/dto/request/ProjectCheckListCreateRequest.java
@@ -16,10 +16,10 @@ public class ProjectCheckListCreateRequest {
 
 	private UUID projectStepId;
 
-	private Boolean approval;
+	private String approval;
 
 	public ProjectCheckListCreateRequest(String title, UUID devCompanyId, UUID clientCompanyId, UUID projectStepId,
-		Boolean approval) {
+		String approval) {
 		this.title = title;
 		this.devCompanyId = devCompanyId;
 		this.clientCompanyId = clientCompanyId;

--- a/src/main/java/kr/mywork/domain/project_checklist/service/dto/response/ProjectCheckListCreateResponse.java
+++ b/src/main/java/kr/mywork/domain/project_checklist/service/dto/response/ProjectCheckListCreateResponse.java
@@ -4,7 +4,8 @@ import java.util.UUID;
 
 import kr.mywork.domain.project_checklist.model.ProjectCheckList;
 
-public record ProjectCheckListCreateResponse(String title, UUID devCompanyId, UUID clientCompanyId, UUID projectStepId, Boolean approval) {
+public record ProjectCheckListCreateResponse(String title, UUID devCompanyId, UUID clientCompanyId, UUID projectStepId,
+											 String approval) {
 
 	public static ProjectCheckListCreateResponse from(ProjectCheckList projectCheckList) {
 		return new ProjectCheckListCreateResponse(projectCheckList.getTitle(), projectCheckList.getDevCompanyId(),

--- a/src/main/java/kr/mywork/domain/project_checklist/service/dto/response/ProjectCheckListDetailResponse.java
+++ b/src/main/java/kr/mywork/domain/project_checklist/service/dto/response/ProjectCheckListDetailResponse.java
@@ -1,0 +1,10 @@
+package kr.mywork.domain.project_checklist.service.dto.response;
+
+import kr.mywork.domain.project_checklist.model.ProjectCheckList;
+
+public record ProjectCheckListDetailResponse(String title, String approval) {
+
+	public ProjectCheckListDetailResponse(ProjectCheckList projectCheckList) {
+		this(projectCheckList.getTitle(), projectCheckList.getApproval());
+	}
+}

--- a/src/main/java/kr/mywork/infrastructure/project_checklist/rdb/QueryDslProjectCheckListRepository.java
+++ b/src/main/java/kr/mywork/infrastructure/project_checklist/rdb/QueryDslProjectCheckListRepository.java
@@ -1,10 +1,14 @@
 package kr.mywork.infrastructure.project_checklist.rdb;
 
+import java.util.Optional;
+import java.util.UUID;
+
 import org.springframework.stereotype.Repository;
 
 import kr.mywork.domain.project_checklist.model.ProjectCheckList;
 import kr.mywork.domain.project_checklist.repository.ProjectCheckListRepository;
 import kr.mywork.domain.project_checklist.service.dto.request.ProjectCheckListCreateRequest;
+import kr.mywork.domain.project_checklist.service.dto.response.ProjectCheckListDetailResponse;
 import lombok.RequiredArgsConstructor;
 
 @Repository
@@ -17,5 +21,10 @@ public class QueryDslProjectCheckListRepository implements ProjectCheckListRepos
 	public ProjectCheckList save(ProjectCheckListCreateRequest projectCheckListCreateRequest) {
 
 		return projectCheckListRepository.save(projectCheckListCreateRequest.toEntity());
+	}
+
+	@Override
+	public Optional<ProjectCheckList> findById(UUID checkListId) {
+		return projectCheckListRepository.findById(checkListId);
 	}
 }

--- a/src/main/java/kr/mywork/interfaces/project_checklist/controller/ProjectCheckListController.java
+++ b/src/main/java/kr/mywork/interfaces/project_checklist/controller/ProjectCheckListController.java
@@ -1,5 +1,9 @@
 package kr.mywork.interfaces.project_checklist.controller;
 
+import java.util.UUID;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
@@ -9,8 +13,10 @@ import kr.mywork.common.api.support.response.ApiResponse;
 import kr.mywork.domain.project_checklist.service.ProjectCheckListService;
 import kr.mywork.domain.project_checklist.service.dto.request.ProjectCheckListCreateRequest;
 import kr.mywork.domain.project_checklist.service.dto.response.ProjectCheckListCreateResponse;
-import kr.mywork.interfaces.project_checklist.controller.dto.response.ProjectCheckListCreateWebResponse;
+import kr.mywork.domain.project_checklist.service.dto.response.ProjectCheckListDetailResponse;
 import kr.mywork.interfaces.project_checklist.controller.dto.request.ProjectCheckListCreateWebRequest;
+import kr.mywork.interfaces.project_checklist.controller.dto.response.ProjectCheckListCreateWebResponse;
+import kr.mywork.interfaces.project_checklist.controller.dto.response.ProjectCheckListDetailWebResponse;
 import lombok.RequiredArgsConstructor;
 
 @RestController
@@ -30,6 +36,17 @@ public class ProjectCheckListController {
 			projectCheckListCreateRequest);
 
 		return ApiResponse.success(new ProjectCheckListCreateWebResponse(projectCheckListCreateResponse));
+	}
+
+	// 패스배리어블 인자로 받는중
+	@GetMapping("/api/projects/check-lists/{checkListId}")
+	public ApiResponse<ProjectCheckListDetailWebResponse> getProjectCheckList(
+		@PathVariable final UUID checkListId) {
+
+		ProjectCheckListDetailResponse projectCheckListDetailResponse = projectCheckListService.getProjectCheckList(
+			checkListId);
+
+		return ApiResponse.success(new ProjectCheckListDetailWebResponse(projectCheckListDetailResponse));
 	}
 
 }

--- a/src/main/java/kr/mywork/interfaces/project_checklist/controller/dto/request/ProjectCheckListCreateWebRequest.java
+++ b/src/main/java/kr/mywork/interfaces/project_checklist/controller/dto/request/ProjectCheckListCreateWebRequest.java
@@ -27,7 +27,7 @@ public class ProjectCheckListCreateWebRequest {
 	private UUID projectStepId;
 
 	@NotNull
-	private Boolean approval;
+	private String approval;
 
 	public ProjectCheckListCreateRequest toServiceDto() {
 		return new ProjectCheckListCreateRequest(this.title, this.devCompanyId, this.clientCompanyId,

--- a/src/main/java/kr/mywork/interfaces/project_checklist/controller/dto/response/ProjectCheckListCreateWebResponse.java
+++ b/src/main/java/kr/mywork/interfaces/project_checklist/controller/dto/response/ProjectCheckListCreateWebResponse.java
@@ -18,7 +18,7 @@ public class ProjectCheckListCreateWebResponse {
 
 	private UUID projectStepId;
 
-	private Boolean approval;
+	private String approval;
 
 	public ProjectCheckListCreateWebResponse(ProjectCheckListCreateResponse projectCheckListCreateResponse) {
 		this.title = projectCheckListCreateResponse.title();

--- a/src/main/java/kr/mywork/interfaces/project_checklist/controller/dto/response/ProjectCheckListDetailWebResponse.java
+++ b/src/main/java/kr/mywork/interfaces/project_checklist/controller/dto/response/ProjectCheckListDetailWebResponse.java
@@ -1,0 +1,10 @@
+package kr.mywork.interfaces.project_checklist.controller.dto.response;
+
+import kr.mywork.domain.project_checklist.service.dto.response.ProjectCheckListDetailResponse;
+
+public record ProjectCheckListDetailWebResponse(String title, String approval) {
+
+	public ProjectCheckListDetailWebResponse(ProjectCheckListDetailResponse response) {
+		this(response.title(), response.approval());
+	}
+}

--- a/src/test/java/kr/mywork/docs/ProjectCheckListDocumentationTest.java
+++ b/src/test/java/kr/mywork/docs/ProjectCheckListDocumentationTest.java
@@ -35,7 +35,7 @@ public class ProjectCheckListDocumentationTest extends RestDocsDocumentation {
 		final UUID projectStepId = UUID.fromString("01991f58-8a6a-7a18-8cfe-1f2bfa6a5e01"); // UUID ver7
 
 		final ProjectCheckListCreateWebRequest projectCheckListCreateWebRequest = new ProjectCheckListCreateWebRequest(
-			"체크리스트 제목", devCompanyId, clientCompanyId, projectStepId, false);
+			"체크리스트 제목", devCompanyId, clientCompanyId, projectStepId, "대기");
 
 		final String requestBody = objectMapper.writeValueAsString(projectCheckListCreateWebRequest);
 
@@ -70,7 +70,47 @@ public class ProjectCheckListDocumentationTest extends RestDocsDocumentation {
 					fieldWithPath("data.devCompanyId").type(JsonFieldType.STRING).description("개발사 id"),
 					fieldWithPath("data.clientCompanyId").type(JsonFieldType.STRING).description("고객사 id"),
 					fieldWithPath("data.projectStepId").type(JsonFieldType.STRING).description("프로젝트 단계 id"),
-					fieldWithPath("data.approval").type(JsonFieldType.BOOLEAN).description("승인여부"),
+					fieldWithPath("data.approval").type(JsonFieldType.STRING).description("승인여부"),
+					fieldWithPath("error").type(JsonFieldType.NULL).description("에러 정보"))
+				.build()
+		);
+	}
+
+	@Test
+	@DisplayName("체크리스트 상세 조회 성공")
+	@Sql("classpath:sql/project-check-list-for-get.sql")
+	void 체크리스트_상세_조회_성공() throws Exception {
+		//given
+		final String accessToken = createSystemAccessToken();
+		final UUID checkListId = UUID.fromString("0196f7a6-10b6-7123-a2dc-32c3861ea55e"); // UUID ver7
+		//when
+		final ResultActions result = mockMvc.perform(
+			get("/api/projects/check-lists/{checkListId}", checkListId)
+				.contentType(MediaType.APPLICATION_JSON)
+				.header(HttpHeaders.AUTHORIZATION, toBearerAuthorizationHeader(accessToken)));
+
+		//then
+		result.andExpectAll(
+				status().isOk(),
+				jsonPath("$.result").value(ResultType.SUCCESS.name()),
+				jsonPath("$.data").exists(),
+				jsonPath("$.error").doesNotExist())
+			.andDo(MockMvcRestDocumentationWrapper.document("project-check-list-get-success", ProjectCheckListGetSuccessResource()));
+	}
+
+	private ResourceSnippet ProjectCheckListGetSuccessResource() {
+		return resource(
+			ResourceSnippetParameters.builder()
+				.tag("ProjectCheckList API")
+				.summary("프로젝트 체크 리스트 상세 조회 API")
+				.description("프로젝트 상세 조회를 한다.")
+				.requestHeaders(
+					headerWithName(HttpHeaders.CONTENT_TYPE).description("컨텐츠 타입"),
+					headerWithName(HttpHeaders.AUTHORIZATION).description("엑세스 토큰"))
+				.responseFields(
+					fieldWithPath("result").type(JsonFieldType.STRING).description("응답 결과"),
+					fieldWithPath("data.title").type(JsonFieldType.STRING).description("체크리스트 제목"),
+					fieldWithPath("data.approval").type(JsonFieldType.STRING).description("승인여부"),
 					fieldWithPath("error").type(JsonFieldType.NULL).description("에러 정보"))
 				.build()
 		);

--- a/src/test/resources/sql/project-check-list-for-get.sql
+++ b/src/test/resources/sql/project-check-list-for-get.sql
@@ -1,0 +1,88 @@
+-- 회사 ID 먼저 생성
+INSERT INTO company_id
+VALUES (UNHEX(REPLACE('1234a9a9-90b6-9898-a9dc-92c9861aa98c', '-', '')));
+INSERT INTO company_id
+VALUES (UNHEX(REPLACE('01973f6c-4b84-70e3-be24-1daf26e5808a', '-', '')));
+
+-- 회사 데이터 생성
+INSERT INTO company (id,
+                     name,
+                     detail,
+                     business_number,
+                     address,
+                     type,
+                     contact_phone_number,
+                     contact_email,
+                     logo_image_path,
+                     created_at,
+                     modified_at,
+                     deleted)
+VALUES (UNHEX(REPLACE('1234a9a9-90b6-9898-a9dc-92c9861aa98c', '-', '')),
+        '고객사 회사',
+        '회사 상세 설명',
+        '323-45-67890',
+        '서울시 강남구 테헤란로 123',
+        'CLIENT',
+        '02-1234-5678',
+        'client@company.com',
+        '/image/url/1234a9a9-90b6-9898-a9dc-92c9861aa98c',
+        NOW(),
+        NOW(),
+        FALSE),
+       (UNHEX(REPLACE('01973f6c-4b84-70e3-be24-1daf26e5808a', '-', '')),
+        '개발사 회사',
+        '회사 상세 설명',
+        '223-45-67890',
+        '서울시 강남구 테헤란로 123',
+        'DEV',
+        '02-1234-5678',
+        'dev@company.com',
+        '/image/url/01973f6c-4b84-70e3-be24-1daf26e5808a',
+        NOW(),
+        NOW(),
+        FALSE);
+
+-- 기획 단계 (order_num: 1)
+INSERT INTO project_step (id, project_id, title, order_num, created_at)
+VALUES (UUID_TO_BIN('01991f58-8a6a-7a18-8cfe-1f2bfa6a5e01'),
+        UUID_TO_BIN('0196f7a6-10b6-7123-a2dc-32c3861ea55e'),
+        '기획', 1, NOW());
+
+-- 디자인 단계 (order_num: 2)
+INSERT INTO project_step (id, project_id, title, order_num, created_at)
+VALUES (UUID_TO_BIN('01991f59-2acb-7a72-a64f-5e1a257bbbe2'),
+        UUID_TO_BIN('0196f7a6-10b6-7123-a2dc-32c3861ea55e'),
+        '디자인', 2, NOW());
+
+-- 개발 단계 (order_num: 3)
+INSERT INTO project_step (id, project_id, title, order_num, created_at)
+VALUES (UUID_TO_BIN('01991f59-6ecf-7a2a-8bb4-92707f10cc0c'),
+        UUID_TO_BIN('0196f7a6-10b6-7123-a2dc-32c3861ea55e'),
+        '개발', 3, NOW());
+
+-- INSERT INTO Project_Check_list (id, title, devCompanyId, clientCompanyId, projectStepId, approval, createdAt)
+-- VALUES (UUID_TO_BIN('0196f7a6-10b6-7123-a2dc-32c3861ea55e'),
+--         '프로젝트 체크 리스트 타이틀',
+--         UUID_TO_BIN('01973f6c-4b84-70e3-be24-1daf26e5808a'),
+--         UUID_TO_BIN('1234a9a9-90b6-9898-a9dc-92c9861aa98c'),
+--         UUID_TO_BIN('01991f58-8a6a-7a18-8cfe-1f2bfa6a5e01'),
+--         '대기',
+--         NOW());
+
+INSERT INTO project_check_list (
+    id,
+    title,
+    dev_company_id,
+    client_company_id,
+    project_step_id,
+    approval,
+    created_at
+) VALUES (
+             UNHEX(REPLACE('0196f7a6-10b6-7123-a2dc-32c3861ea55e', '-', '')),
+             '프로젝트 체크 리스트 타이틀',
+             UNHEX(REPLACE('01973f6c-4b84-70e3-be24-1daf26e5808a', '-', '')),
+             UNHEX(REPLACE('1234a9a9-90b6-9898-a9dc-92c9861aa98c', '-', '')),
+             UNHEX(REPLACE('01991f58-8a6a-7a18-8cfe-1f2bfa6a5e01', '-', '')),
+             '대기',
+             NOW()
+);


### PR DESCRIPTION
## 📌 개요
- 체크리스트 상세조회 API

## 🛠️ 변경 사항
- 체크리스트 상세조회 API구현합니다.

## ✅ 주요 체크 포인트

- [x] : 체크리스트 엔티티의 approval 필드 타입을 Boolean -> String 으로 변경하였습니다. 승인여부가 수정요청, yes, no 3가지라 String으로 변경하였습니다.

## 🔁 테스트 결과
요청, 응답 :
<img width="924" alt="스크린샷 2025-06-07 오후 1 18 14" src="https://github.com/user-attachments/assets/498a78a8-0f92-4f80-8de8-1904e8067162" />

쿼리 결과 : 
```zsh
Hibernate: select pcl1_0.id,pcl1_0.approval,pcl1_0.client_company_id,pcl1_0.created_at,pcl1_0.dev_company_id,pcl1_0.project_step_id,pcl1_0.title from project_check_list pcl1_0 where pcl1_0.id=?
```


## 🔗 연관된 이슈
- #90 

<br>