### PR TITLE
fix: 프로젝트 스탭 생성시 projectId 추가

### DIFF
--- a/src/main/java/kr/mywork/domain/project_step/model/ProjectStep.java
+++ b/src/main/java/kr/mywork/domain/project_step/model/ProjectStep.java
@@ -8,11 +8,17 @@ import org.hibernate.annotations.CreationTimestamp;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
 import kr.mywork.common.rdb.id.UnixTimeOrderedUuidGeneratedValue;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+@Table(
+	name = "project_step",
+	uniqueConstraints = @UniqueConstraint(columnNames = {"project_id", "order_num"})
+)
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
@@ -33,12 +39,13 @@ public class ProjectStep {
 	@Column(nullable = false)
 	private LocalDateTime createdAt;
 
-    public ProjectStep(final String title, final Integer orderNum) {
+    public ProjectStep(final String title, final Integer orderNum, final UUID projectId) {
         this.title = title;
         this.orderNum = orderNum;
+		this.projectId = projectId;
     }
 
-    public boolean update(final String title, final Integer orderNum) {
+	public boolean update(final String title, final Integer orderNum) {
         this.title = title;
         this.orderNum = orderNum;
         return true;

--- a/src/main/java/kr/mywork/domain/project_step/serivce/ProjectStepService.java
+++ b/src/main/java/kr/mywork/domain/project_step/serivce/ProjectStepService.java
@@ -29,7 +29,7 @@ public class ProjectStepService {
 		// TODO projectId 를 기반으로 Project 존재 유무 검증 필요
 
 		final List<ProjectStep> projectSteps = projectStepCreateRequests.stream()
-			.map(ProjectStepCreateRequest::toEntity)
+			.map(request -> request.toEntity(projectId))
 			.toList();
 
 		final List<ProjectStep> savedProjectSteps = projectStepRepository.saveAll(projectSteps);

--- a/src/main/java/kr/mywork/domain/project_step/serivce/dto/request/ProjectStepCreateRequest.java
+++ b/src/main/java/kr/mywork/domain/project_step/serivce/dto/request/ProjectStepCreateRequest.java
@@ -1,10 +1,12 @@
 package kr.mywork.domain.project_step.serivce.dto.request;
 
+import java.util.UUID;
+
 import kr.mywork.domain.project_step.model.ProjectStep;
 
 public record ProjectStepCreateRequest(String title, Integer orderNum) {
 
-	public ProjectStep toEntity() {
-		return new ProjectStep(this.title, this.orderNum);
+	public ProjectStep toEntity(UUID projectId) {
+		return new ProjectStep(this.title, this.orderNum,projectId);
 	}
 }


### PR DESCRIPTION
## 📌 개요

- 프로젝트 스탭 생성 API 수정

## 🛠️ 변경 사항
- 프로젝트 스탭 생성시 projectId 추가
- 중복 방지 엔티티에 추가

## ✅ 주요 체크 포인트

- [ ] 프로젝트 스탭 생성 API
- [ ] 테스트 

## 🔁 테스트 결과
통합테스트
![image](https://github.com/user-attachments/assets/4b8a11fd-dc9a-4254-9483-76103b4a6a73)

## 🔗 연관된 이슈
#122 
#33 