### PR TITLE
[fix]  멤버 상세 조회 필드 추가

### DIFF
--- a/src/main/java/kr/mywork/domain/company/service/dto/response/MemberDetailResponse.java
+++ b/src/main/java/kr/mywork/domain/company/service/dto/response/MemberDetailResponse.java
@@ -1,5 +1,6 @@
 package kr.mywork.domain.company.service.dto.response;
 
+import java.time.LocalDateTime;
 import java.util.UUID;
 
 public record MemberDetailResponse(
@@ -11,6 +12,9 @@ public record MemberDetailResponse(
 	String role,
 	String phoneNumber,
 	String email,
-	Boolean deleted
+	Boolean deleted,
+	LocalDateTime modifiedAt,
+	LocalDateTime createdAt,
+	String contactPhoneNumber
 ) {
 }

--- a/src/main/java/kr/mywork/domain/member/service/dto/response/MemberProjectInfoResponse.java
+++ b/src/main/java/kr/mywork/domain/member/service/dto/response/MemberProjectInfoResponse.java
@@ -1,0 +1,6 @@
+package kr.mywork.domain.member.service.dto.response;
+
+import java.util.UUID;
+
+public record MemberProjectInfoResponse (UUID projectId, String projectName){
+}

--- a/src/main/java/kr/mywork/domain/project/repository/ProjectRepository.java
+++ b/src/main/java/kr/mywork/domain/project/repository/ProjectRepository.java
@@ -4,9 +4,9 @@ import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
+import kr.mywork.domain.member.service.dto.response.MemberProjectInfoResponse;
 import kr.mywork.domain.project.model.Project;
 import kr.mywork.domain.project.service.dto.request.ProjectCreateRequest;
-import kr.mywork.domain.project.service.dto.response.ProjectSelectResponse;
 import kr.mywork.domain.project.service.dto.response.ProjectSelectWithAssignResponse;
 
 public interface ProjectRepository {
@@ -28,4 +28,6 @@ public interface ProjectRepository {
 		String nameKeyword,
 		Boolean deleted
 	);
+
+	List<MemberProjectInfoResponse> findeMemberProjectList(UUID memberId);
 }

--- a/src/main/java/kr/mywork/domain/project/service/ProjectService.java
+++ b/src/main/java/kr/mywork/domain/project/service/ProjectService.java
@@ -10,6 +10,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import kr.mywork.domain.member.model.Member;
 import kr.mywork.domain.member.repository.MemberRepository;
+import kr.mywork.domain.member.service.dto.response.MemberProjectInfoResponse;
 import kr.mywork.domain.project.errors.ProjectErrorType;
 import kr.mywork.domain.project.errors.ProjectNotFoundException;
 import kr.mywork.domain.project.repository.ProjectRepository;
@@ -97,5 +98,13 @@ public class ProjectService {
 				member.getId(),
 				member.getName()
 			)).collect(Collectors.toList());
+	}
+
+	@Transactional
+	public List<MemberProjectInfoResponse> findProjectsAssignedMember(UUID memberId) {
+
+		List<MemberProjectInfoResponse> memberProjectList = projectRepository.findeMemberProjectList(memberId);
+
+		return memberProjectList;
 	}
 }

--- a/src/main/java/kr/mywork/infrastructure/member/rdb/QueryDslMemberRepository.java
+++ b/src/main/java/kr/mywork/infrastructure/member/rdb/QueryDslMemberRepository.java
@@ -1,7 +1,7 @@
 package kr.mywork.infrastructure.member.rdb;
 
-import static kr.mywork.domain.member.model.QMember.member;
 import static kr.mywork.domain.company.model.QCompany.company;
+import static kr.mywork.domain.member.model.QMember.member;
 
 import java.util.List;
 import java.util.Optional;
@@ -11,7 +11,6 @@ import org.springframework.stereotype.Repository;
 
 import com.querydsl.core.BooleanBuilder;
 import com.querydsl.core.types.Projections;
-import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 
 import kr.mywork.domain.company.service.dto.response.MemberDetailResponse;
@@ -171,7 +170,10 @@ public class QueryDslMemberRepository implements MemberRepository {
 			member.role.stringValue(),
 			member.phoneNumber,
 			member.email,
-			member.deleted
+			member.deleted,
+			member.modifiedAt,
+			member.createdAt,
+			company.contactPhoneNumber
 			))
 			.from(member)
 			.join(company).on(member.companyId.eq(company.id))

--- a/src/main/java/kr/mywork/infrastructure/project/rdb/QueryDslProjectRepository.java
+++ b/src/main/java/kr/mywork/infrastructure/project/rdb/QueryDslProjectRepository.java
@@ -15,11 +15,11 @@ import com.querydsl.core.types.Projections;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 
+import kr.mywork.domain.member.service.dto.response.MemberProjectInfoResponse;
 import kr.mywork.domain.project.model.Project;
 import kr.mywork.domain.project.model.ProjectAssign;
 import kr.mywork.domain.project.repository.ProjectRepository;
 import kr.mywork.domain.project.service.dto.request.ProjectCreateRequest;
-import kr.mywork.domain.project.service.dto.response.ProjectSelectResponse;
 import kr.mywork.domain.project.service.dto.response.ProjectSelectWithAssignResponse;
 import lombok.RequiredArgsConstructor;
 
@@ -28,9 +28,9 @@ import lombok.RequiredArgsConstructor;
 @Transactional
 public class QueryDslProjectRepository implements ProjectRepository {
 
-	private final JpaProjectRepository       projectRepository;
+	private final JpaProjectRepository projectRepository;
 	private final JpaProjectAssignRepository projectAssignRepository;
-	private final JPAQueryFactory            queryFactory;
+	private final JPAQueryFactory queryFactory;
 
 	@Override
 	public Project save(ProjectCreateRequest request) {
@@ -108,6 +108,22 @@ public class QueryDslProjectRepository implements ProjectRepository {
 				eqDeleted(deleted)
 			)
 			.fetchOne();
+	}
+
+	@Override
+	public List<MemberProjectInfoResponse> findeMemberProjectList(UUID memberId) {
+		return queryFactory.select(Projections.constructor(
+				MemberProjectInfoResponse.class,
+				projectMember.projectId,
+				project.name
+			))
+			.from(projectMember)
+			.leftJoin(project).on(projectMember.projectId.eq(project.id))
+			.where(
+				eqMember(memberId),
+				eqDeleted(false)
+			)
+			.fetch();
 	}
 
 	private BooleanExpression eqMember(UUID memberId) {

--- a/src/main/java/kr/mywork/interfaces/member/controller/dto/response/MemberDetailsWebResponse.java
+++ b/src/main/java/kr/mywork/interfaces/member/controller/dto/response/MemberDetailsWebResponse.java
@@ -1,8 +1,9 @@
 package kr.mywork.interfaces.member.controller.dto.response;
 
+import java.time.LocalDateTime;
+import java.util.List;
 import java.util.UUID;
 
-import kr.mywork.domain.auth.dto.MemberDetails;
 import kr.mywork.domain.company.service.dto.response.MemberDetailResponse;
 
 public record MemberDetailsWebResponse(
@@ -14,19 +15,29 @@ public record MemberDetailsWebResponse(
 	String role,
 	String phoneNumber,
 	String email,
-	Boolean deleted
+	Boolean deleted,
+	LocalDateTime modifiedAt,
+	LocalDateTime createdAt,
+	String contactPhoneNumber,
+	List<MemberProjectInfoWebResponse> projects
 ) {
-	public static MemberDetailsWebResponse from(MemberDetailResponse response) {
+
+	public static MemberDetailsWebResponse from(
+		MemberDetailResponse memberDetailResponse, List<MemberProjectInfoWebResponse> projects) {
 		return new MemberDetailsWebResponse(
-			response.companyId(),
-			response.companyName(),
-			response.name(),
-			response.department(),
-			response.position(),
-			response.role(),
-			response.phoneNumber(),
-			response.email(),
-			response.deleted()
+			memberDetailResponse.companyId(),
+			memberDetailResponse.companyName(),
+			memberDetailResponse.name(),
+			memberDetailResponse.department(),
+			memberDetailResponse.position(),
+			memberDetailResponse.role(),
+			memberDetailResponse.phoneNumber(),
+			memberDetailResponse.email(),
+			memberDetailResponse.deleted(),
+			memberDetailResponse.modifiedAt(),
+			memberDetailResponse.createdAt(),
+			memberDetailResponse.contactPhoneNumber(),
+			projects
 		);
 	}
 }

--- a/src/main/java/kr/mywork/interfaces/member/controller/dto/response/MemberProjectInfoWebResponse.java
+++ b/src/main/java/kr/mywork/interfaces/member/controller/dto/response/MemberProjectInfoWebResponse.java
@@ -1,0 +1,12 @@
+package kr.mywork.interfaces.member.controller.dto.response;
+
+import java.util.UUID;
+
+import kr.mywork.domain.member.service.dto.response.MemberProjectInfoResponse;
+
+public record MemberProjectInfoWebResponse(UUID projectId, String projectName) {
+
+	public static MemberProjectInfoWebResponse from(final MemberProjectInfoResponse response) {
+		return new MemberProjectInfoWebResponse(response.projectId(), response.projectName());
+	}
+}

--- a/src/test/java/kr/mywork/docs/MemberDocumentationTest.java
+++ b/src/test/java/kr/mywork/docs/MemberDocumentationTest.java
@@ -296,11 +296,11 @@ public class MemberDocumentationTest extends RestDocsDocumentation {
 	void 멤버_상세_조회_성공() throws Exception {
 		//given
 		final String accessToken = createDevAdminAccessToken();
-		UUID memberId = UUID.fromString("60828da5-dc7c-4b8f-ace4-2833e5f74c24");
+		UUID memberId = UUID.fromString("51a58807-bf20-4160-b4e0-edabba6df8f9");
 
 		//when
 		final ResultActions result = mockMvc.perform(
-			get("/api/member/{meberId}", memberId)
+			get("/api/member/{memberId}", memberId)
 				.contentType(MediaType.APPLICATION_JSON)
 				.header(HttpHeaders.AUTHORIZATION, toBearerAuthorizationHeader(accessToken)));
 		//then
@@ -325,6 +325,11 @@ public class MemberDocumentationTest extends RestDocsDocumentation {
 				fieldWithPath("data.phoneNumber").type(JsonFieldType.STRING).description("멤버 전화번호"),
 				fieldWithPath("data.email").type(JsonFieldType.STRING).description("멤버 이메일"),
 				fieldWithPath("data.deleted").type(JsonFieldType.BOOLEAN).description("멤버 삭제여부"),
+				fieldWithPath("data.modifiedAt").type(JsonFieldType.STRING).description("멤버 수정일"),
+				fieldWithPath("data.createdAt").type(JsonFieldType.STRING).description("멤버 생성일"),
+				fieldWithPath("data.contactPhoneNumber").type(JsonFieldType.STRING).description("멤버 회사 연락처"),
+				fieldWithPath("data.projects[].projectId").type(JsonFieldType.STRING).description("멤버 참여중인 프로젝트 아이디"),
+				fieldWithPath("data.projects[].projectName").type(JsonFieldType.STRING).description("멤버 참여중인 프로젝트 이름"),
 				fieldWithPath("error").type(JsonFieldType.NULL).description("에러 정보"))
 			.build());
 	}

--- a/src/test/resources/sql/member-get-detail.sql
+++ b/src/test/resources/sql/member-get-detail.sql
@@ -1,39 +1,80 @@
-INSERT INTO company (
-    deleted,
-    created_at,
-    modified_at,
-    id,
-    name,
-    contact_phone_number,
-    business_number,
-    address,
-    contact_email,
-    detail,
-    logo_image_path,
-    type
-) VALUES (
-             0,
-             NOW(),
-             NOW(),
-             UNHEX(REPLACE('6939d8be-1bf2-4f01-9189-12864e38d913', '-', '')),
-             'Test Company',
-             '+82-10-0000-0000',
-             '1234567890',
-             '123 Test Street, Test City',
-             'testcompany@example.com',
-             'Test company for documentation test',
-             NULL,
-             'CLIENT'
-         );
+-- 회사
+INSERT INTO company (id, name, contact_email, business_number, address, contact_phone_number, created_at, modified_at, type, logo_image_path, deleted, detail)
+VALUES (UUID_TO_BIN('6939d8be-1bf2-4f01-9189-12864e38d913'),
+        '테스트 회사',
+        'testcompany@example.com',
+        '123-45-67890',
+        '서울시 테스트구 테스트로 123',
+        '02-1234-5678',
+        NOW(), NOW(),
+        'DEV',
+        '/path/to/logo.png',
+        0,
+        '테스트 회사 상세 정보');
 
+-- 프로젝트
+INSERT INTO project (id, name, start_at, end_at, step, created_at, modified_at, detail, deleted)
+VALUES (UUID_TO_BIN('01974f0b-5c7a-7fa2-9aba-1323490b77e9'),
+        '테스트 프로젝트',
+        NOW(),
+        NOW(),
+        'STEP1',
+        NOW(),
+        NOW(),
+        '테스트용 프로젝트입니다',
+        0);
+
+-- 멤버추가
 INSERT INTO member (
     id, company_id, name, department, position,
     role, phone_number, email, password, deleted,
     created_at, modified_at, birth_date
 ) VALUES (
-             UNHEX(REPLACE('60828da5-dc7c-4b8f-ace4-2833e5f74c24', '-', '')),
+             UNHEX(REPLACE('c03b1d71-a83d-42af-8c5e-d373cd506e70', '-', '')),
              UNHEX(REPLACE('6939d8be-1bf2-4f01-9189-12864e38d913', '-', '')),
-             '오세훈', '디자인팀', '차장',
-             'DEV_ADMIN', '010-4387-3160', 'user0@example.com', 'pass0', 0,
-             NOW(), NOW(), '1988-01-13 07:11:55'
+             '최지현', '개발팀', '부장',
+             'ANONYMOUS', '010-1239-5705', 'user3@example.com', 'pass3', 0,
+             NOW(), NOW(), '2006-02-14 07:11:55'
          );
+INSERT INTO member (
+    id, company_id, name, department, position,
+    role, phone_number, email, password, deleted,
+    created_at, modified_at, birth_date
+) VALUES (
+             UNHEX(REPLACE('51a58807-bf20-4160-b4e0-edabba6df8f9', '-', '')),
+             UNHEX(REPLACE('6939d8be-1bf2-4f01-9189-12864e38d913', '-', '')),
+             '오세훈', '디자인팀', '사원',
+             'CLIENT_ADMIN', '010-8878-3310', 'user4@example.com', 'pass4', 0,
+             NOW(), NOW(), '1978-05-21 07:11:55'
+         );
+INSERT INTO member (
+    id, company_id, name, department, position,
+    role, phone_number, email, password, deleted,
+    created_at, modified_at, birth_date
+) VALUES (
+             UNHEX(REPLACE('346cdf98-f47b-4d13-bbe4-bd3d0ea48504', '-', '')),
+             UNHEX(REPLACE('6939d8be-1bf2-4f01-9189-12864e38d913', '-', '')),
+             '최지현', '디자인팀', '과장',
+             'SYSTEM_ADMIN', '010-1334-3788', 'user5@example.com', 'pass5', 0,
+             NOW(), NOW(), '1980-11-17 07:11:55'
+         );
+
+-- 할당 멤버
+INSERT INTO project_member (id, project_id, member_id, manager, deleted, created_at)
+VALUES
+    (
+        UUID_TO_BIN('01974f20-3bbe-7d0d-a27e-097667886779'),
+        UUID_TO_BIN('01974f0b-5c7a-7fa2-9aba-1323490b77e9'),
+        UUID_TO_BIN('51a58807-bf20-4160-b4e0-edabba6df8f9'),
+        0,
+        0,
+        NOW()
+    ),
+    (
+        UUID_TO_BIN('01974f20-5db9-70af-a445-ea979366a7cb'),
+        UUID_TO_BIN('01974f0b-5c7a-7fa2-9aba-1323490b77e9'),
+        UUID_TO_BIN('346cdf98-f47b-4d13-bbe4-bd3d0ea48504'),
+        0,
+        0,
+        NOW()
+    );


### PR DESCRIPTION
## 📌 개요
멤버 상세 조회 필드 추가

## 🛠️ 변경 사항
- 프로젝트 리스트 및 회사전화번호 , 생성일 ,수정일 값을 추가함

## ✅ 주요 체크 포인트

- [ ] 멤버 상세 조회 APi
- [ ] 테스트

## 🔁 테스트 결과
<img width="1354" alt="image" src="https://github.com/user-attachments/assets/8a473b5d-002f-4be6-b899-4cbf2372f786" />

<img width="778" alt="image" src="https://github.com/user-attachments/assets/734a23c2-55b9-4450-85f7-ea373bea00cf" />

## 🔗 연관된 이슈

- 해당 PR 과 연관된 이슈를 연결해 주세요.
#136  - fix 수정 이슈
#120 - 기존작업
