### PR TITLE
[feat] 프로젝트 참여중 직원 삭제

### DIFF
--- a/src/main/java/kr/mywork/domain/project/model/ProjectMember.java
+++ b/src/main/java/kr/mywork/domain/project/model/ProjectMember.java
@@ -48,4 +48,8 @@ public class ProjectMember {
 		this.deleted = false;
 		this.createdAt = LocalDateTime.now();
 	}
+
+	public void delete() {
+		this.deleted = true;
+	}
 }

--- a/src/main/java/kr/mywork/domain/project_member/error/ProjectMemberErrorCode.java
+++ b/src/main/java/kr/mywork/domain/project_member/error/ProjectMemberErrorCode.java
@@ -1,0 +1,5 @@
+package kr.mywork.domain.project_member.error;
+
+public enum ProjectMemberErrorCode {
+	ERROR_PROJECT_MEMBER01,
+}

--- a/src/main/java/kr/mywork/domain/project_member/error/ProjectMemberErrorType.java
+++ b/src/main/java/kr/mywork/domain/project_member/error/ProjectMemberErrorType.java
@@ -1,0 +1,13 @@
+package kr.mywork.domain.project_member.error;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum ProjectMemberErrorType {
+	PROJECT_MEMBER_NOT_FOUND(ProjectMemberErrorCode.ERROR_PROJECT_MEMBER01, "프로젝트의 멤버를 찾을 수 없습니다.");
+
+	private final ProjectMemberErrorCode errorCode;
+	private final String message;
+}

--- a/src/main/java/kr/mywork/domain/project_member/error/ProjectMemberException.java
+++ b/src/main/java/kr/mywork/domain/project_member/error/ProjectMemberException.java
@@ -1,0 +1,13 @@
+package kr.mywork.domain.project_member.error;
+
+import lombok.Getter;
+
+@Getter
+public abstract class ProjectMemberException extends RuntimeException {
+	private final ProjectMemberErrorType errorType;
+
+	public ProjectMemberException(final ProjectMemberErrorType errorType) {
+		super(errorType.getMessage());
+		this.errorType = errorType;
+	}
+}

--- a/src/main/java/kr/mywork/domain/project_member/error/ProjectMemberNotFoundException.java
+++ b/src/main/java/kr/mywork/domain/project_member/error/ProjectMemberNotFoundException.java
@@ -1,0 +1,7 @@
+package kr.mywork.domain.project_member.error;
+
+public class ProjectMemberNotFoundException extends ProjectMemberException {
+	public ProjectMemberNotFoundException(final ProjectMemberErrorType errorType) {
+		super(errorType);
+	}
+}

--- a/src/main/java/kr/mywork/domain/project_member/repository/ProjectMemberRepository.java
+++ b/src/main/java/kr/mywork/domain/project_member/repository/ProjectMemberRepository.java
@@ -1,6 +1,7 @@
 package kr.mywork.domain.project_member.repository;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 
 import kr.mywork.domain.project.model.ProjectMember;
@@ -9,4 +10,5 @@ import kr.mywork.domain.project_member.service.dto.response.CompanyMemberInProje
 public interface ProjectMemberRepository {
 	ProjectMember save(ProjectMember projectMember);
 	List<CompanyMemberInProjectResponse> findCompanyMembersInProject(UUID projectId,UUID companyId);
+	Optional<ProjectMember> findByMemberId(UUID memberId,UUID projectId);
 }

--- a/src/main/java/kr/mywork/domain/project_member/service/ProjectMemberService.java
+++ b/src/main/java/kr/mywork/domain/project_member/service/ProjectMemberService.java
@@ -7,6 +7,8 @@ import org.springframework.stereotype.Service;
 
 import jakarta.transaction.Transactional;
 import kr.mywork.domain.project.model.ProjectMember;
+import kr.mywork.domain.project_member.error.ProjectMemberErrorType;
+import kr.mywork.domain.project_member.error.ProjectMemberNotFoundException;
 import kr.mywork.domain.project_member.repository.ProjectMemberRepository;
 import kr.mywork.domain.project_member.service.dto.response.CompanyMemberInProjectResponse;
 import lombok.RequiredArgsConstructor;
@@ -31,5 +33,15 @@ public class ProjectMemberService {
 	public List<CompanyMemberInProjectResponse> findCompanyMembersInProject (UUID projectId,UUID companyId) {
 
 		return projectMemberRepository.findCompanyMembersInProject(projectId,companyId);
+	}
+
+	@Transactional
+	public UUID deleteMemberById(UUID memberId,UUID projectId) {
+		ProjectMember projectMember = projectMemberRepository.findByMemberId(memberId,projectId)
+			.orElseThrow(()-> new ProjectMemberNotFoundException(ProjectMemberErrorType.PROJECT_MEMBER_NOT_FOUND));
+
+		projectMember.delete();
+
+		return projectMember.getId();
 	}
 }

--- a/src/main/java/kr/mywork/infrastructure/member/rdb/QueryDslMemberRepository.java
+++ b/src/main/java/kr/mywork/infrastructure/member/rdb/QueryDslMemberRepository.java
@@ -94,10 +94,8 @@ public class QueryDslMemberRepository implements MemberRepository {
 	public Long countTotalmembersByCondition(final String keyword, final String keywordType,final UUID companyId) {
 		BooleanBuilder builder = new BooleanBuilder();
 
-		// companyId 조건 추가
-		if (companyId != null) {
-			builder.and(member.companyId.eq(companyId));
-		}
+		builder.and(member.deleted.eq(false));
+		if (companyId != null) {builder.and(member.companyId.eq(companyId));}
 
 		if (keyword != null && keywordType != null) {
 			switch (keywordType) {
@@ -122,10 +120,10 @@ public class QueryDslMemberRepository implements MemberRepository {
 		BooleanBuilder builder = new BooleanBuilder();
 		final int offset = (page - 1) * memberPageSize;
 
-		// companyId 조건 추가
-		if (companyId != null) {
-			builder.and(member.companyId.eq(companyId));
-		}
+
+
+		builder.and(member.deleted.eq(false));
+		if (companyId != null) {builder.and(member.companyId.eq(companyId));}
 
 		if (keyword != null && keywordType != null) {
 			switch (keywordType) {

--- a/src/main/java/kr/mywork/infrastructure/project_member/rdb/JpaProjectMemberRepository.java
+++ b/src/main/java/kr/mywork/infrastructure/project_member/rdb/JpaProjectMemberRepository.java
@@ -1,5 +1,6 @@
 package kr.mywork.infrastructure.project_member.rdb;
 
+import java.util.Optional;
 import java.util.UUID;
 
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -7,4 +8,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import kr.mywork.domain.project.model.ProjectMember;
 
 public interface JpaProjectMemberRepository extends JpaRepository<ProjectMember, UUID> {
+	Optional<ProjectMember> findByMemberIdAndProjectId(UUID memberId, UUID projectId);
 }

--- a/src/main/java/kr/mywork/infrastructure/project_member/rdb/QueryDslProjectMemberRepository.java
+++ b/src/main/java/kr/mywork/infrastructure/project_member/rdb/QueryDslProjectMemberRepository.java
@@ -1,11 +1,14 @@
 package kr.mywork.infrastructure.project_member.rdb;
 
+import static kr.mywork.domain.member.model.QMember.member;
+import static kr.mywork.domain.project.model.QProjectMember.projectMember;
+
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 
 import org.springframework.stereotype.Repository;
-import static kr.mywork.domain.member.model.QMember.member;
-import static kr.mywork.domain.project.model.QProjectMember.projectMember;
+
 import com.querydsl.core.types.Projections;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 
@@ -46,5 +49,9 @@ public class QueryDslProjectMemberRepository implements ProjectMemberRepository 
 			.fetch();
 	}
 
+	@Override
+	public Optional<ProjectMember> findByMemberId(UUID memberId,UUID projectId) {
+		return jpaProjectMemberRepository.findByMemberIdAndProjectId(memberId,projectId);
+	}
 
 }

--- a/src/main/java/kr/mywork/interfaces/project_member/controller/ProjectMemberController.java
+++ b/src/main/java/kr/mywork/interfaces/project_member/controller/ProjectMemberController.java
@@ -3,6 +3,7 @@ package kr.mywork.interfaces.project_member.controller;
 import java.util.List;
 import java.util.UUID;
 
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -14,6 +15,7 @@ import kr.mywork.domain.project_member.service.ProjectMemberService;
 import kr.mywork.domain.project_member.service.dto.response.CompanyMemberInProjectResponse;
 import kr.mywork.interfaces.project_member.controller.dto.response.CompanyMembersInProjectWebResponse;
 import kr.mywork.interfaces.project_member.controller.dto.response.ProjectMemberAddWebResponse;
+import kr.mywork.interfaces.project_member.controller.dto.response.ProjectMemberDeleteWebResponse;
 import lombok.RequiredArgsConstructor;
 
 @RestController
@@ -44,6 +46,17 @@ public class ProjectMemberController {
 
 		return ApiResponse.success(CompanyMembersInProjectWebResponse.from(companyMemberInProjectResponseList));
 		
+	}
+	@DeleteMapping  //전달 받은 멤버를 프로젝트 멤버에서 제외한다.
+	public ApiResponse<ProjectMemberDeleteWebResponse> deleteProjectMember(
+		@RequestParam(name="memberId") UUID memberId,
+		@RequestParam(name="projectId") UUID projectId
+	) {
+		final UUID deletedMemberId =projectMemberService.deleteMemberById(memberId,projectId);
+
+		final ProjectMemberDeleteWebResponse projectMemberDeleteWebResponse = new ProjectMemberDeleteWebResponse(deletedMemberId);
+
+		return ApiResponse.success(projectMemberDeleteWebResponse);
 	}
 }
 

--- a/src/main/java/kr/mywork/interfaces/project_member/controller/dto/response/ProjectMemberDeleteWebResponse.java
+++ b/src/main/java/kr/mywork/interfaces/project_member/controller/dto/response/ProjectMemberDeleteWebResponse.java
@@ -1,0 +1,6 @@
+package kr.mywork.interfaces.project_member.controller.dto.response;
+
+import java.util.UUID;
+
+public record ProjectMemberDeleteWebResponse(UUID memberId) {
+}

--- a/src/test/java/kr/mywork/docs/ProjectMemberDocumentationTest.java
+++ b/src/test/java/kr/mywork/docs/ProjectMemberDocumentationTest.java
@@ -109,4 +109,45 @@ public class ProjectMemberDocumentationTest extends RestDocsDocumentation {
 					fieldWithPath("error").type(JsonFieldType.NULL).description("에러 정보"))
 				.build());
 	}
+	@Test
+	@DisplayName("프로젝트 멤버 삭제 성공")
+	@Sql("classpath:sql/project-member-delete.sql")
+	void 프로젝트_멤버_삭제_성공() throws Exception {
+		// given
+		final String accessToken = createDevAdminAccessToken();
+
+		final UUID projectId = UUID.fromString("01974f0b-5c7a-7fa2-9aba-1323490b77e9");
+		final UUID memberId = UUID.fromString("6939d8be-1bf2-4f01-9189-12864e38d913");
+
+		// when
+		final ResultActions result = mockMvc.perform(delete("/api/project-member")
+			.param("memberId", memberId.toString())
+			.param("projectId", projectId.toString())
+			.header(HttpHeaders.AUTHORIZATION, toBearerAuthorizationHeader(accessToken))
+			.contentType(MediaType.APPLICATION_JSON));
+
+		// then
+		result.andExpectAll(
+				status().isOk(),
+				jsonPath("$.result").value(ResultType.SUCCESS.name()),
+				jsonPath("$.data").exists(),
+				jsonPath("$.error").doesNotExist())
+			.andDo(document("project-member-delete-success", projectMemberDeleteSuccessResource()));
+	}
+
+	private ResourceSnippet projectMemberDeleteSuccessResource() {
+		return resource(
+			ResourceSnippetParameters.builder()
+				.tag("Project Member API")
+				.summary("프로젝트 멤버 삭제 API")
+				.description("프로젝트 멤버를 삭제한다")
+				.requestHeaders(
+					headerWithName(HttpHeaders.CONTENT_TYPE).description("컨텐츠 타입"),
+					headerWithName(HttpHeaders.AUTHORIZATION).description("엑세스 토큰"))
+				.responseFields(
+					fieldWithPath("result").type(JsonFieldType.STRING).description("응답 결과"),
+					fieldWithPath("data.memberId").type(JsonFieldType.STRING).description("삭제된 프로젝트 멤버 아이디"),
+					fieldWithPath("error").type(JsonFieldType.NULL).description("에러 정보"))
+				.build());
+	}
 }

--- a/src/test/resources/sql/project-member-delete.sql
+++ b/src/test/resources/sql/project-member-delete.sql
@@ -1,0 +1,80 @@
+-- 회사
+INSERT INTO company (id, name, contact_email, business_number, address, contact_phone_number, created_at, modified_at, type, logo_image_path, deleted, detail)
+VALUES (UUID_TO_BIN('6939d8be-1bf2-4f01-9189-12864e38d913'),
+        '테스트 회사',
+        'testcompany@example.com',
+        '123-45-67890',
+        '서울시 테스트구 테스트로 123',
+        '02-1234-5678',
+        NOW(), NOW(),
+        'DEV',
+        '/path/to/logo.png',
+        0,
+        '테스트 회사 상세 정보');
+
+-- 프로젝트
+INSERT INTO project (id, name, start_at, end_at, step, created_at, modified_at, detail, deleted)
+VALUES (UUID_TO_BIN('01974f0b-5c7a-7fa2-9aba-1323490b77e9'),
+        '테스트 프로젝트',
+        NOW(),
+        NOW(),
+        'STEP1',
+        NOW(),
+        NOW(),
+        '테스트용 프로젝트입니다',
+        0);
+
+-- 멤버추가
+INSERT INTO member (
+    id, company_id, name, department, position,
+    role, phone_number, email, password, deleted,
+    created_at, modified_at, birth_date
+) VALUES (
+             UNHEX(REPLACE('c03b1d71-a83d-42af-8c5e-d373cd506e70', '-', '')),
+             UNHEX(REPLACE('6939d8be-1bf2-4f01-9189-12864e38d913', '-', '')),
+             '최지현', '개발팀', '부장',
+             'ANONYMOUS', '010-1239-5705', 'user3@example.com', 'pass3', 0,
+             NOW(), NOW(), '2006-02-14 07:11:55'
+         );
+INSERT INTO member (
+    id, company_id, name, department, position,
+    role, phone_number, email, password, deleted,
+    created_at, modified_at, birth_date
+) VALUES (
+             UNHEX(REPLACE('51a58807-bf20-4160-b4e0-edabba6df8f9', '-', '')),
+             UNHEX(REPLACE('6939d8be-1bf2-4f01-9189-12864e38d913', '-', '')),
+             '오세훈', '디자인팀', '사원',
+             'CLIENT_ADMIN', '010-8878-3310', 'user4@example.com', 'pass4', 0,
+             NOW(), NOW(), '1978-05-21 07:11:55'
+         );
+INSERT INTO member (
+    id, company_id, name, department, position,
+    role, phone_number, email, password, deleted,
+    created_at, modified_at, birth_date
+) VALUES (
+             UNHEX(REPLACE('346cdf98-f47b-4d13-bbe4-bd3d0ea48504', '-', '')),
+             UNHEX(REPLACE('6939d8be-1bf2-4f01-9189-12864e38d913', '-', '')),
+             '최지현', '디자인팀', '과장',
+             'SYSTEM_ADMIN', '010-1334-3788', 'user5@example.com', 'pass5', 0,
+             NOW(), NOW(), '1980-11-17 07:11:55'
+         );
+
+-- 할당 멤버
+INSERT INTO project_member (id, project_id, member_id, manager, deleted, created_at)
+VALUES
+    (
+        UUID_TO_BIN('01974f20-3bbe-7d0d-a27e-097667886779'),
+        UUID_TO_BIN('01974f0b-5c7a-7fa2-9aba-1323490b77e9'),
+        UUID_TO_BIN('6939d8be-1bf2-4f01-9189-12864e38d913'),
+        0,
+        0,
+        NOW()
+    ),
+    (
+        UUID_TO_BIN('01974f20-5db9-70af-a445-ea979366a7cb'),
+        UUID_TO_BIN('01974f0b-5c7a-7fa2-9aba-1323490b77e9'),
+        UUID_TO_BIN('346cdf98-f47b-4d13-bbe4-bd3d0ea48504'),
+        0,
+        0,
+        NOW()
+    );


### PR DESCRIPTION
## 📌 개요

- 프로젝트 참여중 직원 삭제

## 🛠️ 변경 사항
- 프로젝트 참여중 직원 삭제
- #120  상세 조건 쿼리 추가 (삭제된 멤버조회는 안되도록)
## ✅ 주요 체크 포인트

- [ ] 프로젝트 참여중 직원 삭제 API
- [ ] 통합 테스트

## 🔁 테스트 결과
<img width="1236" alt="image" src="https://github.com/user-attachments/assets/f7ce295a-5bc0-4c63-9fdc-fdabf38cd2d7" />

JPA 에 따른 쿼리문
Hibernate: select pm1_0.id,pm1_0.created_at,pm1_0.deleted,pm1_0.manager,pm1_0.member_id,pm1_0.project_id from project_member pm1_0 where pm1_0.member_id=? and pm1_0.project_id=?
Hibernate: update project_member set created_at=?,deleted=?,manager=?,member_id=?,project_id=? where id=?

## 🔗 연관된 이슈
#152 #120 