### PR TITLE
[feat] 컨트롤러 파라미터에 인증 정보 전달 로직 추가

### DIFF
--- a/src/main/java/kr/mywork/common/auth/components/annotation/LoginMember.java
+++ b/src/main/java/kr/mywork/common/auth/components/annotation/LoginMember.java
@@ -1,0 +1,11 @@
+package kr.mywork.common.auth.components.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.PARAMETER)
+public @interface LoginMember {
+}

--- a/src/main/java/kr/mywork/common/auth/components/argument_resolver/LoginUserArgumentResolver.java
+++ b/src/main/java/kr/mywork/common/auth/components/argument_resolver/LoginUserArgumentResolver.java
@@ -1,0 +1,37 @@
+package kr.mywork.common.auth.components.argument_resolver;
+
+import org.springframework.core.MethodParameter;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+import kr.mywork.common.auth.components.annotation.LoginMember;
+import kr.mywork.common.auth.components.dto.LoginMemberDetail;
+import kr.mywork.domain.auth.dto.MemberDetails;
+
+@Component
+public class LoginUserArgumentResolver implements HandlerMethodArgumentResolver {
+
+	@Override
+	public boolean supportsParameter(final MethodParameter parameter) {
+		return parameter.getParameterAnnotation(LoginMember.class) != null;
+	}
+
+	@Override
+	public Object resolveArgument(final MethodParameter parameter, final ModelAndViewContainer mavContainer,
+		final NativeWebRequest webRequest, final WebDataBinderFactory binderFactory) throws Exception {
+		Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+
+		if (authentication == null) {
+			return null;
+		}
+
+		final MemberDetails memberDetails = (MemberDetails)authentication.getPrincipal();
+
+		return new LoginMemberDetail(memberDetails.getId(), memberDetails.getName(), memberDetails.getCompanyId());
+	}
+}

--- a/src/main/java/kr/mywork/common/auth/components/dto/LoginMemberDetail.java
+++ b/src/main/java/kr/mywork/common/auth/components/dto/LoginMemberDetail.java
@@ -1,0 +1,6 @@
+package kr.mywork.common.auth.components.dto;
+
+import java.util.UUID;
+
+public record LoginMemberDetail(UUID memberId, String memberName, UUID companyId) {
+}

--- a/src/main/java/kr/mywork/common/auth/config/AuthenticationArgumentConfig.java
+++ b/src/main/java/kr/mywork/common/auth/config/AuthenticationArgumentConfig.java
@@ -1,0 +1,22 @@
+package kr.mywork.common.auth.config;
+
+import java.util.List;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import kr.mywork.common.auth.components.argument_resolver.LoginUserArgumentResolver;
+import lombok.RequiredArgsConstructor;
+
+@Configuration
+@RequiredArgsConstructor
+public class AuthenticationArgumentConfig implements WebMvcConfigurer {
+
+	private final LoginUserArgumentResolver loginUserArgumentResolver;
+
+	@Override
+	public void addArgumentResolvers(final List<HandlerMethodArgumentResolver> resolvers) {
+		resolvers.add(loginUserArgumentResolver);
+	}
+}

--- a/src/main/java/kr/mywork/common/auth/config/JwtProperties.java
+++ b/src/main/java/kr/mywork/common/auth/config/JwtProperties.java
@@ -1,4 +1,4 @@
-package kr.mywork.common.auth;
+package kr.mywork.common.auth.config;
 
 import lombok.Getter;
 import lombok.Setter;

--- a/src/main/java/kr/mywork/common/auth/config/SecurityConfig.java
+++ b/src/main/java/kr/mywork/common/auth/config/SecurityConfig.java
@@ -22,7 +22,6 @@ import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 
-import kr.mywork.common.auth.JwtProperties;
 import kr.mywork.domain.auth.service.JwtTokenProvider;
 import kr.mywork.domain.auth.service.TokenAuthenticationService;
 import kr.mywork.domain.member.model.MemberRole;

--- a/src/main/java/kr/mywork/domain/auth/service/JwtTokenProvider.java
+++ b/src/main/java/kr/mywork/domain/auth/service/JwtTokenProvider.java
@@ -8,7 +8,7 @@ import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.security.Keys;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
-import kr.mywork.common.auth.JwtProperties;
+import kr.mywork.common.auth.config.JwtProperties;
 import kr.mywork.domain.auth.errors.InvalidTokenException;
 import kr.mywork.domain.auth.errors.TokenExpiredException;
 import kr.mywork.domain.auth.errors.AuthErrorType;

--- a/src/main/java/kr/mywork/interfaces/company/controller/CompanyController.java
+++ b/src/main/java/kr/mywork/interfaces/company/controller/CompanyController.java
@@ -17,6 +17,8 @@ import org.springframework.web.bind.annotation.RestController;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.Pattern;
 import kr.mywork.common.api.support.response.ApiResponse;
+import kr.mywork.common.auth.components.annotation.LoginUser;
+import kr.mywork.common.auth.components.dto.LoginMemberDetail;
 import kr.mywork.domain.company.service.CompanyService;
 import kr.mywork.domain.company.service.dto.request.CompanyCreateRequest;
 import kr.mywork.domain.company.service.dto.request.CompanyUpdateRequest;

--- a/src/main/java/kr/mywork/interfaces/company/controller/CompanyController.java
+++ b/src/main/java/kr/mywork/interfaces/company/controller/CompanyController.java
@@ -17,8 +17,6 @@ import org.springframework.web.bind.annotation.RestController;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.Pattern;
 import kr.mywork.common.api.support.response.ApiResponse;
-import kr.mywork.common.auth.components.annotation.LoginUser;
-import kr.mywork.common.auth.components.dto.LoginMemberDetail;
 import kr.mywork.domain.company.service.CompanyService;
 import kr.mywork.domain.company.service.dto.request.CompanyCreateRequest;
 import kr.mywork.domain.company.service.dto.request.CompanyUpdateRequest;


### PR DESCRIPTION
## 📌 개요

- 컨트롤러 파라미터에 인증 정보 전달 로직 추가

## 🛠️ 변경 사항

- 컨트롤러 인증 정보 전달 ArgumentResolver 개발

## ✅ 주요 체크 포인트

- [x] 컨트롤러 파라미터로 @LoginMember + LoginMemberDetail 을 추가했을 때 값이 정상 주입 확인 필요
- [x] 인증되지 않는 API calll 에 관한 로직 추가 검토 필요

## 🔁 테스트 결과

## LoginMemberDetail ArgumentResolver 를 통한 전달 로직 추가 시 데이터 결과

<img width="883" alt="Image" src="https://github.com/user-attachments/assets/bbdfcb2f-6a6d-4382-a108-2332bb662e41" />

<img width="1409" alt="Image" src="https://github.com/user-attachments/assets/68ad9603-1b9d-4bcd-8d51-2f0574030529" />

## 🔗 연관된 이슈

- #154 
