### PR TITLE
fix: 회사 목록 조회 로직 수정

### DIFF
--- a/src/main/java/kr/mywork/infrastructure/company/rdb/QueryDslCompanyRepository.java
+++ b/src/main/java/kr/mywork/infrastructure/company/rdb/QueryDslCompanyRepository.java
@@ -44,7 +44,8 @@ public class QueryDslCompanyRepository implements CompanyRepository {
 	}
 
 	@Override
-	public List<CompanySelectResponse> findCompaniesBySearchConditionWithPaging(final int page, final int companyPageSize,
+	public List<CompanySelectResponse> findCompaniesBySearchConditionWithPaging(final int page,
+		final int companyPageSize,
 		final String companyType, final String keywordType, String keyword, Boolean deleted) {
 
 		final int offset = (page - 1) * companyPageSize;
@@ -113,8 +114,14 @@ public class QueryDslCompanyRepository implements CompanyRepository {
 				company.id,
 				company.name))
 			.from(company)
-			.where(company.deleted.isFalse(),
-				company.type.stringValue().eq(companyType))
+			.where(
+				eqCompanyType(companyType),
+				company.deleted.eq(false)
+			)
 			.fetch();
+	}
+
+	public BooleanExpression eqCompanyType(final String companyType) {
+		return (companyType == null) ? null : company.type.stringValue().eq(companyType);
 	}
 }

--- a/src/main/java/kr/mywork/interfaces/company/controller/CompanyController.java
+++ b/src/main/java/kr/mywork/interfaces/company/controller/CompanyController.java
@@ -126,7 +126,7 @@ public class CompanyController {
 
 	@GetMapping("/names")
 	public ApiResponse<CompanyNamesWebResponse> companyListOnlyIdNameWebResponseApiResponse(
-		@RequestParam(name = "companyType") @Pattern(regexp = COMPANY_TYPE_REGX, message = "{invalid.company-type}") final String companyType) {
+		@RequestParam(name = "companyType",required = false) @Pattern(regexp = COMPANY_TYPE_REGX, message = "{invalid.company-type}") final String companyType) {
 		final List<CompanyNameResponse> companyNames = companyService.findCompanyNamesByCompanyType(companyType);
 
 		final List<CompanyNameWebResponse> companyNameWebResponses = companyNames.stream()


### PR DESCRIPTION
## 📌 개요
-회사 타입이 없을때 모든 회사 목록이 내려올수 있도록 수정.

## 🛠️ 변경 사항
- companyType null 값 허용
- null 허용에 따른 쿼리에 동적쿼리 적용.

## ✅ 주요 체크 포인트

- [ ] 영향도 있는 프론트 화면 확인. ( DEV/ CLIENT or NULL)
- [ ] 테스트 
## 🔁 테스트 결과
Type 없이 조회 
-회사 타입이 없을때 모든 회사 목록이 내려올수 있도록 수정.
<img width="1000" alt="image" src="https://github.com/user-attachments/assets/ead72494-c6cb-4bf2-b43c-2ad201ec8bec" />

회사 타입이 있을떄 조회
<img width="1000" alt="image" src="https://github.com/user-attachments/assets/63a9f1d5-db3c-446e-ad69-65deeb76362e" />

## 🔗 연관된 이슈
#155 