### PR TITLE
[feat] 임시 CORS 허용 URL 추가

### DIFF
--- a/src/main/java/kr/mywork/common/auth/config/SecurityConfig.java
+++ b/src/main/java/kr/mywork/common/auth/config/SecurityConfig.java
@@ -148,7 +148,8 @@ public class SecurityConfig {
 	public CorsConfigurationSource corsConfigurationSource() {
 		CorsConfiguration config = new CorsConfiguration();
 
-		config.setAllowedOrigins(List.of("http://localhost:3000", "https://d16zykr4498a0c.cloudfront.net"));
+		config.setAllowedOrigins(List.of("http://localhost:3000", "https://d16zykr4498a0c.cloudfront.net",
+			"http://mywork-fe-bucket.s3-website.ap-northeast-2.amazonaws.com"));
 		config.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE", "OPTIONS"));
 		config.setAllowedHeaders(List.of("*"));
 		config.setAllowCredentials(true); // 쿠키, 인증 정보 포함 시 필수


### PR DESCRIPTION
## 📌 개요

- 임시 CORS 허용 URL 추가

## 🛠️ 변경 사항

- HTTPS 적용 과정에서 AWS ACM 의 인증서 발급 대기로 인한 개발 서버 환경 테스트를 위한 임시 URL 추가

## ✅ 주요 체크 포인트

- [ ] http://mywork-fe-bucket.s3-website.ap-northeast-2.amazonaws.com/ 정상 동작 확인

## 🔁 테스트 결과

테스트 코드 추가 변화가 없습니다.

## 🔗 연관된 이슈

- #166 
