### PR TITLE
[fix] 프로젝트 멤버 재등록 과정에서 등록이 실패하는 이슈

### DIFF
--- a/src/main/java/kr/mywork/domain/project/model/ProjectMember.java
+++ b/src/main/java/kr/mywork/domain/project/model/ProjectMember.java
@@ -52,4 +52,8 @@ public class ProjectMember {
 	public void delete() {
 		this.deleted = true;
 	}
+
+	public void restore() {
+		this.deleted = false;
+	}
 }

--- a/src/main/java/kr/mywork/domain/project_member/repository/ProjectMemberRepository.java
+++ b/src/main/java/kr/mywork/domain/project_member/repository/ProjectMemberRepository.java
@@ -11,4 +11,5 @@ public interface ProjectMemberRepository {
 	ProjectMember save(ProjectMember projectMember);
 	List<CompanyMemberInProjectResponse> findCompanyMembersInProject(UUID projectId,UUID companyId);
 	Optional<ProjectMember> findByMemberIdAndProjectId(UUID memberId,UUID projectId);
+	boolean existsByMemberIdAndProjectIdAndDeleted(UUID memberId, UUID projectId, boolean deleted);
 }

--- a/src/main/java/kr/mywork/infrastructure/project_member/rdb/QueryDslProjectMemberRepository.java
+++ b/src/main/java/kr/mywork/infrastructure/project_member/rdb/QueryDslProjectMemberRepository.java
@@ -54,4 +54,16 @@ public class QueryDslProjectMemberRepository implements ProjectMemberRepository 
 		return jpaProjectMemberRepository.findByMemberIdAndProjectId(memberId,projectId);
 	}
 
+	@Override
+	public boolean existsByMemberIdAndProjectIdAndDeleted(final UUID memberId, final UUID projectId,
+		final boolean deleted) {
+		return queryFactory.select(projectMember.id)
+			.from(projectMember)
+			.where(projectMember.deleted.isTrue()
+				.and(projectMember.memberId.eq(memberId))
+				.and(projectMember.projectId.eq(projectId)))
+			.limit(1)
+			.fetchFirst() != null;
+	}
+
 }

--- a/src/test/java/kr/mywork/domain/project_member/service/ProjectMemberServiceTest.java
+++ b/src/test/java/kr/mywork/domain/project_member/service/ProjectMemberServiceTest.java
@@ -1,0 +1,72 @@
+package kr.mywork.domain.project_member.service;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import java.util.Optional;
+import java.util.UUID;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import kr.mywork.domain.project.model.ProjectMember;
+import kr.mywork.domain.project_member.repository.ProjectMemberRepository;
+
+class ProjectMemberServiceTest {
+
+	private ProjectMemberService projectMemberService;
+	private ProjectMemberRepository projectMemberRepository;
+
+	@BeforeEach
+	void setUp() {
+		this.projectMemberRepository = Mockito.mock(ProjectMemberRepository.class);
+		this.projectMemberService = new ProjectMemberService(projectMemberRepository);
+	}
+
+	@Test
+	@DisplayName("제거된 프로젝트 멤버를 다시 할당하면 기존 프로젝트 멤버를 호출한다")
+	void 제거된_프로젝트_멤버를_다시_할당하면_기존_프로젝트_멤버를_호출한다 () {
+	    // given
+		final UUID projectId = UUID.fromString("01975df2-edc4-74b7-83b6-47c96d2c2deb");
+		final UUID memberId = UUID.fromString("01975df3-3e13-7b2f-b99b-2cb28f0eeecb");
+
+		given(projectMemberRepository.existsByMemberIdAndProjectIdAndDeleted(any(), any(), anyBoolean()))
+			.willReturn(true);
+		given(projectMemberRepository.findByMemberIdAndProjectId(any(), any()))
+			.willReturn(Optional.of(new ProjectMember(projectId, memberId)));
+
+		// when
+		projectMemberService.addMemberToCompany(projectId, memberId);
+
+		// then
+		verify(projectMemberRepository, times(1)).findByMemberIdAndProjectId(any(), any());
+		verify(projectMemberRepository, never()).save(any());
+	}
+
+	@Test
+	@DisplayName("제거된 프로젝트 멤버가 없으면 프로젝트 멤버를 생성한다")
+	void 제거된_프로젝트_멤버가_없으면_프로젝트_멤버를_생성한다 () {
+		// given
+		final UUID projectId = UUID.fromString("01975df2-edc4-74b7-83b6-47c96d2c2deb");
+		final UUID memberId = UUID.fromString("01975df3-3e13-7b2f-b99b-2cb28f0eeecb");
+
+		given(projectMemberRepository.existsByMemberIdAndProjectIdAndDeleted(any(), any(), anyBoolean()))
+			.willReturn(false);
+		given(projectMemberRepository.save(any()))
+			.willReturn(new ProjectMember(projectId, memberId));
+
+		// when
+		projectMemberService.addMemberToCompany(projectId, memberId);
+
+		// then
+		verify(projectMemberRepository, never()).findByMemberIdAndProjectId(any(), any());
+		verify(projectMemberRepository, times(1)).save(any());
+	}
+
+}


### PR DESCRIPTION
## 📌 개요

- 프로젝트 멤버 재등록 과정에서 등록이 실패하는 이슈

## 🛠️ 변경 사항

- 기존 삭제된 프로젝트 멤버 조회 및 삭제 제거 로직 추가

## ✅ 주요 체크 포인트

- [ ] 리뷰어가 중점적으로 봐야 할 부분이 있다면 적어주세요.
- [ ] 예: validation 처리 방식, 성능 개선 등

## 🔁 테스트 결과

- ProjectMemberServiceTest 에 테스트 케이스 추가 (4954280)

## 🔗 연관된 이슈

- #165

<br>
