### PR TITLE
fix : 회사 삭제 API 수정

### DIFF
--- a/src/main/java/kr/mywork/interfaces/company/controller/CompanyController.java
+++ b/src/main/java/kr/mywork/interfaces/company/controller/CompanyController.java
@@ -26,15 +26,14 @@ import kr.mywork.domain.company.service.dto.response.CompanySelectResponse;
 import kr.mywork.domain.member.service.MemberService;
 import kr.mywork.domain.member.service.dto.response.CompanyMemberResponse;
 import kr.mywork.interfaces.company.controller.dto.request.CompanyCreateWebRequest;
-import kr.mywork.interfaces.company.controller.dto.request.CompanyDeleteWebRequest;
 import kr.mywork.interfaces.company.controller.dto.request.CompanyUpdateWebRequest;
 import kr.mywork.interfaces.company.controller.dto.response.CompanyCreateWebResponse;
 import kr.mywork.interfaces.company.controller.dto.response.CompanyDeleteWebResponse;
 import kr.mywork.interfaces.company.controller.dto.response.CompanyDetailWebResponse;
 import kr.mywork.interfaces.company.controller.dto.response.CompanyIdCreateWebResponse;
+import kr.mywork.interfaces.company.controller.dto.response.CompanyListWebResponse;
 import kr.mywork.interfaces.company.controller.dto.response.CompanyNameWebResponse;
 import kr.mywork.interfaces.company.controller.dto.response.CompanyNamesWebResponse;
-import kr.mywork.interfaces.company.controller.dto.response.CompanyListWebResponse;
 import kr.mywork.interfaces.company.controller.dto.response.CompanySelectWebResponse;
 import kr.mywork.interfaces.company.controller.dto.response.CompanyUpdateWebResponse;
 import kr.mywork.interfaces.member.controller.dto.response.CompanyMemberListWebResponse;
@@ -85,10 +84,10 @@ public class CompanyController {
 		return ApiResponse.success(companyUpdateWebResponse);
 	}
 
-	@DeleteMapping
+	@DeleteMapping("/{companyId}")
 	public ApiResponse<CompanyDeleteWebResponse> deleteCompany(
-		@RequestBody final CompanyDeleteWebRequest companyDeleteWebRequest) {
-		final UUID deleteCompanyId = companyService.deleteCompany(companyDeleteWebRequest.id());
+		@PathVariable (name="companyId")UUID companyId) {
+		final UUID deleteCompanyId = companyService.deleteCompany(companyId);
 
 		final CompanyDeleteWebResponse companyDeleteWebResponse = new CompanyDeleteWebResponse(deleteCompanyId);
 

--- a/src/test/java/kr/mywork/docs/CompanyDocumentationTest.java
+++ b/src/test/java/kr/mywork/docs/CompanyDocumentationTest.java
@@ -29,7 +29,6 @@ import com.fasterxml.uuid.Generators;
 
 import kr.mywork.common.api.support.response.ResultType;
 import kr.mywork.interfaces.company.controller.dto.request.CompanyCreateWebRequest;
-import kr.mywork.interfaces.company.controller.dto.request.CompanyDeleteWebRequest;
 import kr.mywork.interfaces.company.controller.dto.request.CompanyUpdateWebRequest;
 
 public class CompanyDocumentationTest extends RestDocsDocumentation {
@@ -273,17 +272,11 @@ public class CompanyDocumentationTest extends RestDocsDocumentation {
 		final String accessToken = createSystemAccessToken();
 
 		UUID companyId = UUID.fromString("0196f7a6-10b6-7123-a2dc-32c3861ea55e"); // company-id.sql과 동일한 값
-		CompanyDeleteWebRequest deleteReq = new CompanyDeleteWebRequest(companyId);
-
-		// JSON 요청 본문 생성
-		String requestBody = objectMapper.writeValueAsString(deleteReq);
-
 		// When
 		ResultActions result = mockMvc.perform(
-			delete("/api/companies", companyId)
+			delete("/api/companies/{companyId}", companyId)
 				.contentType(MediaType.APPLICATION_JSON)
 				.header(HttpHeaders.AUTHORIZATION, toBearerAuthorizationHeader(accessToken))
-				.content(requestBody)
 		);
 
 		// Then


### PR DESCRIPTION
## 📌 개요

- 회사 삭제 API 수정

## 🛠️ 변경 사항

회사 삭제 API  변경 값을 하나만 받지만 requestBody로받음
pathvariable 로 변경 프론트 호출 형식과동일하게 변경

## ✅ 주요 체크 포인트

- [ ] 삭제성공

## 🔁 테스트 결과

- 화면 테스트 완료.

## 🔗 연관된 이슈
#176 