### PR TITLE
feat  프로젝트 멤버의 리스트  조회 API

### DIFF
--- a/src/main/java/kr/mywork/interfaces/member/controller/MemberController.java
+++ b/src/main/java/kr/mywork/interfaces/member/controller/MemberController.java
@@ -33,6 +33,7 @@ import kr.mywork.interfaces.member.controller.dto.response.MemberDeleteWebRespon
 import kr.mywork.interfaces.member.controller.dto.response.MemberDetailsWebResponse;
 import kr.mywork.interfaces.member.controller.dto.response.MemberListWebResponse;
 import kr.mywork.interfaces.member.controller.dto.response.MemberProjectInfoWebResponse;
+import kr.mywork.interfaces.member.controller.dto.response.MemberProjectsListWebResponse;
 import kr.mywork.interfaces.member.controller.dto.response.MemberSelectWebResponse;
 import kr.mywork.interfaces.member.controller.dto.response.MemberUpdateWebResponse;
 import kr.mywork.interfaces.member.controller.dto.response.ResetPasswordWebResponse;
@@ -125,5 +126,18 @@ public class MemberController {
 		ResetPasswordWebResponse resetPasswordWebResponse = new ResetPasswordWebResponse(memberId);
 
 		return ApiResponse.success(resetPasswordWebResponse);
+	}
+
+	@GetMapping("/{memberId}/myProjects")
+	public ApiResponse<MemberProjectsListWebResponse> getMemberProjectInfo(@PathVariable("memberId") final UUID memberId) {
+
+		List<MemberProjectInfoResponse> memberProjectInfoResponse = projectService.findProjectsAssignedMember(memberId);
+
+		List<MemberProjectInfoWebResponse> memberAssignProjectWebResponses = memberProjectInfoResponse.stream()
+			.map(MemberProjectInfoWebResponse::from)
+			.toList();
+
+		MemberProjectsListWebResponse memberProjectsListWebResponse = new MemberProjectsListWebResponse(memberAssignProjectWebResponses);
+		return ApiResponse.success(memberProjectsListWebResponse);
 	}
 }

--- a/src/main/java/kr/mywork/interfaces/member/controller/dto/response/MemberProjectsListWebResponse.java
+++ b/src/main/java/kr/mywork/interfaces/member/controller/dto/response/MemberProjectsListWebResponse.java
@@ -1,0 +1,6 @@
+package kr.mywork.interfaces.member.controller.dto.response;
+
+import java.util.List;
+
+public record MemberProjectsListWebResponse(List<MemberProjectInfoWebResponse> projects) {
+}

--- a/src/test/java/kr/mywork/docs/MemberDocumentationTest.java
+++ b/src/test/java/kr/mywork/docs/MemberDocumentationTest.java
@@ -280,4 +280,35 @@ public class MemberDocumentationTest extends RestDocsDocumentation {
 				fieldWithPath("error").type(JsonFieldType.NULL).description("에러 정보"))
 			.build());
 	}
+
+
+	@Test
+	@DisplayName("멤버의 프로젝트 목록 조회 성공")
+	@Sql("classpath:sql/member-projects-get.sql")
+	void 멤버_프로젝트_목록_조회_성공() throws Exception {
+		//given
+		final String accessToken = createDevAdminAccessToken();
+		//when
+		final ResultActions result = mockMvc.perform(
+			get("/api/member/{memberId}/myProjects", UUID.fromString("6939d8be-1bf2-4f01-9189-12864e38d913"))
+				.contentType(MediaType.APPLICATION_JSON)
+				.header(HttpHeaders.AUTHORIZATION, toBearerAuthorizationHeader(accessToken)));
+
+		//then
+		result.andExpectAll(status().isOk(), jsonPath("$.result").value(ResultType.SUCCESS.name()),
+				jsonPath("$.data").exists(), jsonPath("$.error").doesNotExist())
+			.andDo(document("member-projects-get-success", memberProjectsGetSuccessResource()));
+	}
+	private ResourceSnippet memberProjectsGetSuccessResource() {
+		return resource(ResourceSnippetParameters.builder()
+			.tag("Member API")
+			.summary("멤버 프로젝트 리스트 조회 API")
+			.description("멤버 프로젝트 리스트 조회 한다.")
+			.requestHeaders(headerWithName(HttpHeaders.CONTENT_TYPE).description("컨텐츠 타입"))
+			.responseFields(fieldWithPath("result").type(JsonFieldType.STRING).description("응답 결과"),
+				fieldWithPath("data.projects[].projectId").type(JsonFieldType.STRING).description("프로젝트 Id"),
+				fieldWithPath("data.projects[].projectName").type(JsonFieldType.STRING).description("프로젝트 이름"),
+				fieldWithPath("error").type(JsonFieldType.NULL).description("에러 정보"))
+			.build());
+	}
 }

--- a/src/test/resources/sql/member-projects-get.sql
+++ b/src/test/resources/sql/member-projects-get.sql
@@ -1,0 +1,80 @@
+-- 회사
+INSERT INTO company (id, name, contact_email, business_number, address, contact_phone_number, created_at, modified_at, type, logo_image_path, deleted, detail)
+VALUES (UUID_TO_BIN('6939d8be-1bf2-4f01-9189-12864e38d913'),
+        '테스트 회사',
+        'testcompany@example.com',
+        '123-45-67890',
+        '서울시 테스트구 테스트로 123',
+        '02-1234-5678',
+        NOW(), NOW(),
+        'DEV',
+        '/path/to/logo.png',
+        0,
+        '테스트 회사 상세 정보');
+
+-- 프로젝트
+INSERT INTO project (id, name, start_at, end_at, step, created_at, modified_at, detail, deleted)
+VALUES (UUID_TO_BIN('01974f0b-5c7a-7fa2-9aba-1323490b77e9'),
+        '테스트 프로젝트',
+        NOW(),
+        NOW(),
+        'STEP1',
+        NOW(),
+        NOW(),
+        '테스트용 프로젝트입니다',
+        0);
+
+-- 멤버추가
+INSERT INTO member (
+    id, company_id, name, department, position,
+    role, phone_number, email, password, deleted,
+    created_at, modified_at, birth_date
+) VALUES (
+             UNHEX(REPLACE('c03b1d71-a83d-42af-8c5e-d373cd506e70', '-', '')),
+             UNHEX(REPLACE('6939d8be-1bf2-4f01-9189-12864e38d913', '-', '')),
+             '최지현', '개발팀', '부장',
+             'ANONYMOUS', '010-1239-5705', 'user3@example.com', 'pass3', 0,
+             NOW(), NOW(), '2006-02-14 07:11:55'
+         );
+INSERT INTO member (
+    id, company_id, name, department, position,
+    role, phone_number, email, password, deleted,
+    created_at, modified_at, birth_date
+) VALUES (
+             UNHEX(REPLACE('51a58807-bf20-4160-b4e0-edabba6df8f9', '-', '')),
+             UNHEX(REPLACE('6939d8be-1bf2-4f01-9189-12864e38d913', '-', '')),
+             '오세훈', '디자인팀', '사원',
+             'CLIENT_ADMIN', '010-8878-3310', 'user4@example.com', 'pass4', 0,
+             NOW(), NOW(), '1978-05-21 07:11:55'
+         );
+INSERT INTO member (
+    id, company_id, name, department, position,
+    role, phone_number, email, password, deleted,
+    created_at, modified_at, birth_date
+) VALUES (
+             UNHEX(REPLACE('346cdf98-f47b-4d13-bbe4-bd3d0ea48504', '-', '')),
+             UNHEX(REPLACE('6939d8be-1bf2-4f01-9189-12864e38d913', '-', '')),
+             '최지현', '디자인팀', '과장',
+             'SYSTEM_ADMIN', '010-1334-3788', 'user5@example.com', 'pass5', 0,
+             NOW(), NOW(), '1980-11-17 07:11:55'
+         );
+
+-- 할당 멤버
+INSERT INTO project_member (id, project_id, member_id, manager, deleted, created_at)
+VALUES
+    (
+        UUID_TO_BIN('01974f20-3bbe-7d0d-a27e-097667886779'),
+        UUID_TO_BIN('01974f0b-5c7a-7fa2-9aba-1323490b77e9'),
+        UUID_TO_BIN('6939d8be-1bf2-4f01-9189-12864e38d913'),
+        0,
+        0,
+        NOW()
+    ),
+    (
+        UUID_TO_BIN('01974f20-5db9-70af-a445-ea979366a7cb'),
+        UUID_TO_BIN('01974f0b-5c7a-7fa2-9aba-1323490b77e9'),
+        UUID_TO_BIN('346cdf98-f47b-4d13-bbe4-bd3d0ea48504'),
+        0,
+        0,
+        NOW()
+    );


### PR DESCRIPTION
## 📌 개요

프로젝트 멤버의 리스트  조회 API

## 🛠️ 변경 사항
프로젝트 멤버의 리스트  조회 API
서비스에 있던 부분을 API 로 분리

## ✅ 주요 체크 포인트

- [ ] 리스트 노출확인.

## 🔁 테스트 결과

![image](https://github.com/user-attachments/assets/b7d6da19-53f7-455f-9aef-fbdfd8ae9ab7)

## 🔗 연관된 이슈
#178 
