### PR TITLE
feat : 게시글 단건 조회 응답에 createdAt 추가

### DIFF
--- a/src/main/java/kr/mywork/domain/post/service/dto/response/PostDetailResponse.java
+++ b/src/main/java/kr/mywork/domain/post/service/dto/response/PostDetailResponse.java
@@ -1,15 +1,16 @@
 package kr.mywork.domain.post.service.dto.response;
 
+import java.time.LocalDateTime;
 import java.util.UUID;
 
 import kr.mywork.domain.post.model.Post;
 
 public record PostDetailResponse(UUID postId, String title, String content, String companyName, String authorName,
-								 String approval) {
+								 String approval, LocalDateTime createdAt) {
 
 	public static PostDetailResponse from(Post post) {
 		return new PostDetailResponse(post.getId(), post.getTitle(), post.getContent(), post.getCompanyName(),
-			post.getAuthorName(), post.getApproval());
+			post.getAuthorName(), post.getApproval(), post.getCreatedAt());
 
 	}
 

--- a/src/main/java/kr/mywork/interfaces/post/controller/dto/response/PostDetailWebResponse.java
+++ b/src/main/java/kr/mywork/interfaces/post/controller/dto/response/PostDetailWebResponse.java
@@ -1,15 +1,18 @@
 package kr.mywork.interfaces.post.controller.dto.response;
 
+import java.time.LocalDateTime;
 import java.util.UUID;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
 
 import kr.mywork.domain.post.service.dto.response.PostDetailResponse;
 
 public record PostDetailWebResponse(UUID postId, String title, String content, String companyName, String authorName,
-									String approval) {
+									String approval, @JsonFormat(pattern = "yyyy-MM-dd HH:mm") LocalDateTime createdAt) {
 
 	public static PostDetailWebResponse from(PostDetailResponse postDetailResponse) {
 		return new PostDetailWebResponse(postDetailResponse.postId(), postDetailResponse.title(),
 			postDetailResponse.content(), postDetailResponse.companyName(), postDetailResponse.authorName(),
-			postDetailResponse.approval());
+			postDetailResponse.approval(), postDetailResponse.createdAt());
 	}
 }

--- a/src/test/java/kr/mywork/docs/PostDocumentationTest.java
+++ b/src/test/java/kr/mywork/docs/PostDocumentationTest.java
@@ -256,6 +256,7 @@ public class PostDocumentationTest extends RestDocsDocumentation {
 					fieldWithPath("data.companyName").type(JsonFieldType.STRING).description("회사 이름"),
 					fieldWithPath("data.authorName").type(JsonFieldType.STRING).description("작성자"),
 					fieldWithPath("data.approval").type(JsonFieldType.STRING).description("승인여부"),
+					fieldWithPath("data.createdAt").type(JsonFieldType.STRING).description("작성일"),
 					fieldWithPath("error").type(JsonFieldType.NULL).description("에러 정보"))
 				.build()
 		);


### PR DESCRIPTION
## 📌 개요
게시글 단건 조회 응답에 createdAt 추가

## 🛠️ 변경 사항
- 게시글 단건 조회 응답에 createdAt 추가

## 🔁 테스트 결과
요청, 응답
<img width="867" alt="스크린샷 2025-06-12 오후 6 10 37" src="https://github.com/user-attachments/assets/3022ab9f-0cf3-4cde-968d-576fac72918b" />

```zsh
Hibernate: select p1_0.id,p1_0.approval,p1_0.author_name,p1_0.company_name,p1_0.content,p1_0.created_at,p1_0.deleted,p1_0.modified_at,p1_0.project_step_id,p1_0.title from post p1_0 where p1_0.id=?
```


## 🔗 연관된 이슈
- #183 