### PR TITLE
[fix] 멤버 본인 프로젝트 목록 접근 불가 문제

### DIFF
--- a/src/main/java/kr/mywork/common/auth/config/SecurityConfig.java
+++ b/src/main/java/kr/mywork/common/auth/config/SecurityConfig.java
@@ -67,7 +67,8 @@ public class SecurityConfig {
 					.requestMatchers("/api/member/**").hasAnyRole(
 						MemberRole.DEV_ADMIN.name(),
 						MemberRole.CLIENT_ADMIN.name(),
-						MemberRole.SYSTEM_ADMIN.name())
+						MemberRole.SYSTEM_ADMIN.name(),
+						MemberRole.USER.name())
 					.requestMatchers("/api/member/company/**").hasAnyRole(
 						MemberRole.DEV_ADMIN.name(),
 						MemberRole.CLIENT_ADMIN.name(),

--- a/src/test/java/kr/mywork/docs/MemberDocumentationTest.java
+++ b/src/test/java/kr/mywork/docs/MemberDocumentationTest.java
@@ -82,8 +82,8 @@ public class MemberDocumentationTest extends RestDocsDocumentation {
 		//given
 		final String accessToken = createSystemAccessToken();
 		final UUID companyId = UUID.fromString("0196f7a6-10b6-7123-a2dc-32c3861ea55e"); // UUID ver7
-		final LocalDateTime birthDate = LocalDateTime.parse("2000-07-25T14:30:00");    
-    
+		final LocalDateTime birthDate = LocalDateTime.parse("2000-07-25T14:30:00");
+
 		final MemberCreateWebRequest memberCreateWebRequest = new MemberCreateWebRequest(companyId, "김두만", "개발", "부장",
 			"USER", "010-4040-5050", "eme@naver.com", birthDate);
 
@@ -269,6 +269,7 @@ public class MemberDocumentationTest extends RestDocsDocumentation {
 				jsonPath("$.data").exists(), jsonPath("$.error").doesNotExist())
 			.andDo(document("member-password-change-success", memberPasswordChangeSuccessResource()));
 	}
+
 	private ResourceSnippet memberPasswordChangeSuccessResource() {
 		return resource(ResourceSnippetParameters.builder()
 			.tag("Member API")
@@ -281,13 +282,12 @@ public class MemberDocumentationTest extends RestDocsDocumentation {
 			.build());
 	}
 
-
 	@Test
-	@DisplayName("멤버의 프로젝트 목록 조회 성공")
+	@DisplayName("멤버의 본인의 프로젝트 상세 조회")
 	@Sql("classpath:sql/member-projects-get.sql")
 	void 멤버_프로젝트_목록_조회_성공() throws Exception {
 		//given
-		final String accessToken = createDevAdminAccessToken();
+		final String accessToken = createUserAccessToken(); // system admin 의 권한이 통과해야 함.
 		//when
 		final ResultActions result = mockMvc.perform(
 			get("/api/member/{memberId}/myProjects", UUID.fromString("6939d8be-1bf2-4f01-9189-12864e38d913"))
@@ -299,6 +299,7 @@ public class MemberDocumentationTest extends RestDocsDocumentation {
 				jsonPath("$.data").exists(), jsonPath("$.error").doesNotExist())
 			.andDo(document("member-projects-get-success", memberProjectsGetSuccessResource()));
 	}
+
 	private ResourceSnippet memberProjectsGetSuccessResource() {
 		return resource(ResourceSnippetParameters.builder()
 			.tag("Member API")


### PR DESCRIPTION
## 📌 개요

- 멤버 본인 프로젝트 목록 접근 불가 문제

## 🛠️ 변경 사항

- 원인 : USER 권한이 접근하지 않는 문제
- 해결 : /api/member 하위 URL 에서 USER 권한 추가

## ✅ 주요 체크 포인트


## 🔁 테스트 결과

- 테스트 코드 USER 접근 권한 추가


## 🔗 연관된 이슈

- #200 

<br>
