### PR TITLE
feat: 프로젝트 다건 삭제 API 및 테스트/문서화 구현 (#204)

### DIFF
--- a/src/main/java/kr/mywork/domain/project/errors/ProjectErrorType.java
+++ b/src/main/java/kr/mywork/domain/project/errors/ProjectErrorType.java
@@ -11,6 +11,6 @@ public enum ProjectErrorType {
 	PROJECT_ID_NOT_FOUND(ProjectErrorCode.ERROR_PROJECT02, "유효한 프로젝트 ID가 아닙니다."),
 	PROJECT_ASSIGN_NOT_FOUND(ProjectErrorCode.ERROR_PROJECT03, "프로젝트 할당을 찾을 수 없습니다.");
 
-	private final ProjectErrorCode code;
+	private final ProjectErrorCode errorCode;
 	private final String message;
 }

--- a/src/main/java/kr/mywork/domain/project/service/ProjectService.java
+++ b/src/main/java/kr/mywork/domain/project/service/ProjectService.java
@@ -71,6 +71,19 @@ public class ProjectService {
 	}
 
 	@Transactional
+	public List<UUID> bulkDeleteProjects(List<UUID> projectIds) {
+		return projectIds.stream()
+			.map(id -> {
+				var project = projectRepository.findById(id)
+					.orElseThrow(() -> new ProjectNotFoundException(ProjectErrorType.PROJECT_NOT_FOUND));
+				project.setDeleted(true);
+				return project.getId();
+			})
+			.toList();
+	}
+
+
+	@Transactional
 	public ProjectUpdateResponse updateProject(UUID projectId, ProjectUpdateRequest request) {
 		var project = projectRepository.findById(projectId)
 			.orElseThrow(() -> new ProjectNotFoundException(ProjectErrorType.PROJECT_NOT_FOUND));

--- a/src/main/java/kr/mywork/interfaces/project/controller/ProjectController.java
+++ b/src/main/java/kr/mywork/interfaces/project/controller/ProjectController.java
@@ -26,6 +26,8 @@ import kr.mywork.domain.project.service.dto.response.ProjectDetailResponse;
 import kr.mywork.domain.project.service.dto.response.ProjectMemberResponse;
 import kr.mywork.domain.project.service.dto.response.ProjectSelectResponse;
 import kr.mywork.domain.project.service.dto.response.ProjectUpdateResponse;
+import kr.mywork.interfaces.project.controller.dto.request.ProjectBulkDeleteWebRequest;
+import kr.mywork.interfaces.project.controller.dto.response.ProjectBulkDeleteWebResponse;
 import kr.mywork.interfaces.project.controller.dto.request.ProjectCreateWebRequest;
 import kr.mywork.interfaces.project.controller.dto.request.ProjectDeleteWebRequest;
 import kr.mywork.interfaces.project.controller.dto.request.ProjectUpdateWebRequest;
@@ -130,5 +132,14 @@ public class ProjectController {
 			projectMemberResponses);
 
 		return ApiResponse.success(projectMemberListWebResponse);
+	}
+
+	@DeleteMapping("/bulk")
+	public ApiResponse<ProjectBulkDeleteWebResponse> bulkDeleteProject(
+		@RequestBody @Valid final ProjectBulkDeleteWebRequest projectBulkDeleteWebRequest
+	) {
+		List<UUID> deletedIds = projectService.bulkDeleteProjects(projectBulkDeleteWebRequest.getIds());
+
+		return ApiResponse.success(new ProjectBulkDeleteWebResponse(deletedIds));
 	}
 }

--- a/src/main/java/kr/mywork/interfaces/project/controller/dto/request/ProjectBulkDeleteWebRequest.java
+++ b/src/main/java/kr/mywork/interfaces/project/controller/dto/request/ProjectBulkDeleteWebRequest.java
@@ -1,0 +1,13 @@
+package kr.mywork.interfaces.project.controller.dto.request;
+
+import java.util.List;
+import java.util.UUID;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class ProjectBulkDeleteWebRequest {
+	private List<UUID> ids;
+}

--- a/src/main/java/kr/mywork/interfaces/project/controller/dto/response/ProjectBulkDeleteWebResponse.java
+++ b/src/main/java/kr/mywork/interfaces/project/controller/dto/response/ProjectBulkDeleteWebResponse.java
@@ -1,0 +1,13 @@
+package kr.mywork.interfaces.project.controller.dto.response;
+
+import java.util.List;
+import java.util.UUID;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class ProjectBulkDeleteWebResponse {
+	private List<UUID> deletedIds;
+}

--- a/src/main/java/kr/mywork/interfaces/project/controller/errors/handler/ProjectControllerAdvice.java
+++ b/src/main/java/kr/mywork/interfaces/project/controller/errors/handler/ProjectControllerAdvice.java
@@ -1,0 +1,26 @@
+package kr.mywork.interfaces.project.controller.errors.handler;
+
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import kr.mywork.common.api.support.response.ApiResponse;
+import kr.mywork.domain.project.errors.ProjectErrorType;
+import kr.mywork.domain.project.errors.ProjectException;
+
+@Order(Ordered.LOWEST_PRECEDENCE - 1)
+@RestControllerAdvice
+public class ProjectControllerAdvice {
+
+	@ExceptionHandler(ProjectException.class)
+	public ResponseEntity<ApiResponse<?>> handleProjectException(ProjectException exception) {
+		final ProjectErrorType errorType = exception.getErrorType();
+
+		return ResponseEntity.badRequest().body(
+			ApiResponse.error(errorType.getErrorCode().name(), errorType.getMessage())
+		);
+	}
+
+}

--- a/src/test/java/kr/mywork/docs/ProjectDocumentationTest.java
+++ b/src/test/java/kr/mywork/docs/ProjectDocumentationTest.java
@@ -344,6 +344,35 @@ public class ProjectDocumentationTest extends RestDocsDocumentation {
 		);
 	}
 
+	@Test
+	@DisplayName("존재하지 않는 프로젝트 ID 다건 삭제 시 실패")
+	void 프로젝트_다건_삭제_비정상_케이스() throws Exception {
+		// given
+		final String accessToken = createSystemAccessToken();
+
+		List<UUID> ids = List.of(
+			UUID.fromString("99999999-9999-9999-9999-999999999999")
+		);
+		ProjectBulkDeleteWebRequest request = new ProjectBulkDeleteWebRequest();
+		Field idsField = ProjectBulkDeleteWebRequest.class.getDeclaredField("ids");
+		idsField.setAccessible(true);
+		idsField.set(request, ids);
+
+		// when
+		final ResultActions result = mockMvc.perform(
+			delete("/api/projects/bulk")
+				.contentType(MediaType.APPLICATION_JSON)
+				.header(HttpHeaders.AUTHORIZATION, toBearerAuthorizationHeader(accessToken))
+				.content(objectMapper.writeValueAsString(request))
+		);
+
+		// then
+		result.andExpect(status().is4xxClientError())
+			.andExpect(jsonPath("$.result").value("ERROR"))
+			.andExpect(jsonPath("$.error").exists());
+	}
+
+
 
 	@Test
 	@DisplayName("프로젝트 목록 조회 성공")

--- a/src/test/resources/sql/project-bulk-delete.sql
+++ b/src/test/resources/sql/project-bulk-delete.sql
@@ -1,0 +1,27 @@
+-- 프로젝트 1
+INSERT INTO project (id, name, start_at, end_at, step, created_at, modified_at, detail, deleted)
+VALUES (
+           UUID_TO_BIN('11111111-1111-1111-1111-111111111111'),
+           '다건삭제프로젝트1',
+           NOW(),
+           NOW(),
+           'IN_PROGRESS',
+           NOW(),
+           NOW(),
+           '다건 삭제 테스트용 프로젝트1',
+           0
+       );
+
+-- 프로젝트 2
+INSERT INTO project (id, name, start_at, end_at, step, created_at, modified_at, detail, deleted)
+VALUES (
+           UUID_TO_BIN('22222222-2222-2222-2222-222222222222'),
+           '다건삭제프로젝트2',
+           NOW(),
+           NOW(),
+           'IN_PROGRESS',
+           NOW(),
+           NOW(),
+           '다건 삭제 테스트용 프로젝트2',
+           0
+       );


### PR DESCRIPTION
## 📌 개요

* 프로젝트 다건 삭제 기능 개발 및 API/테스트/문서화를 진행했습니다.

---

## 🛠️ 변경 사항

* 프로젝트 다건 삭제 요청/응답 DTO 추가
* bulkDeleteProjects 서비스 로직 구현
* 다건 삭제 API 컨트롤러(`@DeleteMapping("/bulk")`) 추가
* 성공/예외 케이스 포함한 테스트 코드
* 성공 케이스 RestDocs 문서 작성

---

## ✅ 주요 체크 포인트

* [ ] 삭제 요청 시 없는 프로젝트 ID 입력에 대한 예외 처리 방식
* [ ] 전체 트랜잭션 롤백 및 응답 값 일관성
* [ ] 테스트 데이터 및 RestDocs 문서 구조 적합성

---

## 🔁 테스트 결과

*  테스트와 RestDocs를 활용해 정상/비정상(없는 ID 등) 케이스 모두 검증하였고,
* 실제 API 요청 시 정상적으로 여러 프로젝트가 일괄 삭제됨을 확인했습니다.

---

## 🔗 연관된 이슈

* #204 

---

## 📑 레퍼런스

* 없음