### PR TITLE
[feat] 대시보드 써머리 조회 API

### DIFF
--- a/src/main/java/kr/mywork/common/auth/components/argument_resolver/LoginUserArgumentResolver.java
+++ b/src/main/java/kr/mywork/common/auth/components/argument_resolver/LoginUserArgumentResolver.java
@@ -33,6 +33,6 @@ public class LoginUserArgumentResolver implements HandlerMethodArgumentResolver 
 		final MemberDetails memberDetails = (MemberDetails)authentication.getPrincipal();
 
 		return new LoginMemberDetail(memberDetails.getId(), memberDetails.getName(), memberDetails.getCompanyId(),
-			memberDetails.getCompanyName());
+			memberDetails.getCompanyName(),memberDetails.getAuthorityAsStr());
 	}
 }

--- a/src/main/java/kr/mywork/common/auth/components/dto/LoginMemberDetail.java
+++ b/src/main/java/kr/mywork/common/auth/components/dto/LoginMemberDetail.java
@@ -2,5 +2,5 @@ package kr.mywork.common.auth.components.dto;
 
 import java.util.UUID;
 
-public record LoginMemberDetail(UUID memberId, String memberName, UUID companyId, String companyName) {
+public record LoginMemberDetail(UUID memberId, String memberName, UUID companyId, String companyName,String userType) {
 }

--- a/src/main/java/kr/mywork/common/auth/config/SecurityConfig.java
+++ b/src/main/java/kr/mywork/common/auth/config/SecurityConfig.java
@@ -150,7 +150,7 @@ public class SecurityConfig {
 		CorsConfiguration config = new CorsConfiguration();
 
 		config.setAllowedOrigins(List.of("http://localhost:3000", "https://d16zykr4498a0c.cloudfront.net",
-			"http://mywork-fe-bucket.s3-website.ap-northeast-2.amazonaws.com"));
+			"https://kbe-mywork.com", "https://www.kbe-mywork.com"));
 		config.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE", "OPTIONS"));
 		config.setAllowedHeaders(List.of("*"));
 		config.setAllowCredentials(true); // 쿠키, 인증 정보 포함 시 필수

--- a/src/main/java/kr/mywork/domain/dashboard/service/DashboardService.java
+++ b/src/main/java/kr/mywork/domain/dashboard/service/DashboardService.java
@@ -1,0 +1,84 @@
+package kr.mywork.domain.dashboard.service;
+
+import java.util.List;
+import java.util.UUID;
+
+import org.springframework.stereotype.Service;
+
+import kr.mywork.domain.dashboard.service.dto.response.DashboardCountSummaryResponse;
+import kr.mywork.domain.dashboard.service.errors.DashboardErrorType;
+import kr.mywork.domain.dashboard.service.errors.DashboardTypeNotFoundException;
+import kr.mywork.domain.dashboard.service.repository.DashboardRepository;
+import kr.mywork.domain.project.model.ProjectAssign;
+import kr.mywork.domain.project.model.ProjectMember;
+import kr.mywork.interfaces.dashboard.controller.dto.request.DashboardCountSummaryWebRequest;
+import kr.mywork.interfaces.dashboard.controller.dto.response.DashboardCountSummaryWebResponse;
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class DashboardService {
+
+	final DashboardRepository dashboardRepository;
+
+	public DashboardCountSummaryWebResponse getSummaryTotalCount(DashboardCountSummaryWebRequest webRequest) {
+
+		final String userType = webRequest.userType();
+		final UUID companyId = webRequest.companyId();
+		final UUID memberId = webRequest.memberId();
+
+		if ("SYSTEMADMIN".equalsIgnoreCase(userType)) {
+			return getAdminSummary();
+		} else if (("DEVADMIN".equalsIgnoreCase(userType) || "CLIENTADMIN".equalsIgnoreCase(userType))
+			&& companyId != null) {
+			return getCompanyAdminSummary(companyId, userType);
+		} else if ("USER".equalsIgnoreCase(userType) && memberId != null) {
+			return getUserSummary(memberId);
+		} else {
+			throw new DashboardTypeNotFoundException(DashboardErrorType.TYPE_NOT_FOUND);
+		}
+	}
+
+	private DashboardCountSummaryWebResponse getAdminSummary() {
+
+		final DashboardCountSummaryResponse dashboardCountSummaryResponse = dashboardRepository.getAdminSummary();
+
+		return DashboardCountSummaryWebResponse.from(dashboardCountSummaryResponse);
+
+	}
+
+	private DashboardCountSummaryWebResponse getCompanyAdminSummary(UUID companyId, String userType) {
+
+		final String type = extractCompanyAdminType(userType);
+
+		final List<UUID> projectIds = dashboardRepository.getCompanyAdminProject(companyId, type).stream()
+			.map(ProjectAssign::getProjectId)
+			.toList();
+
+		final DashboardCountSummaryResponse dashboardCountSummaryResponse = dashboardRepository.getCompanyAdminSummary(
+			projectIds);
+
+		return DashboardCountSummaryWebResponse.from(dashboardCountSummaryResponse);
+	}
+
+	private DashboardCountSummaryWebResponse getUserSummary(UUID memberId) {
+
+		final List<UUID> projectIds = dashboardRepository.getUserProject(memberId).stream()
+			.map(ProjectMember::getProjectId)
+			.toList();
+
+		final DashboardCountSummaryResponse dashboardCountSummaryResponse = dashboardRepository.getUserSummary(projectIds);
+
+		return DashboardCountSummaryWebResponse.from(dashboardCountSummaryResponse);
+	}
+
+	private String extractCompanyAdminType(String userType) {
+		if (userType.equalsIgnoreCase("SYSTEMADMIN"))
+			return "system";
+		if (userType.equalsIgnoreCase("DEVADMIN"))
+			return "dev";
+		if (userType.equalsIgnoreCase("CLIENTADMIN"))
+			return "client";
+		return "user";
+	}
+}

--- a/src/main/java/kr/mywork/domain/dashboard/service/DashboardService.java
+++ b/src/main/java/kr/mywork/domain/dashboard/service/DashboardService.java
@@ -1,19 +1,18 @@
 package kr.mywork.domain.dashboard.service;
 
-import java.util.List;
-import java.util.UUID;
-
-import org.springframework.stereotype.Service;
-
+import kr.mywork.common.auth.components.dto.LoginMemberDetail;
 import kr.mywork.domain.dashboard.service.dto.response.DashboardCountSummaryResponse;
 import kr.mywork.domain.dashboard.service.errors.DashboardErrorType;
 import kr.mywork.domain.dashboard.service.errors.DashboardTypeNotFoundException;
 import kr.mywork.domain.dashboard.service.repository.DashboardRepository;
 import kr.mywork.domain.project.model.ProjectAssign;
 import kr.mywork.domain.project.model.ProjectMember;
-import kr.mywork.interfaces.dashboard.controller.dto.request.DashboardCountSummaryWebRequest;
 import kr.mywork.interfaces.dashboard.controller.dto.response.DashboardCountSummaryWebResponse;
 import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.UUID;
 
 @Service
 @RequiredArgsConstructor
@@ -21,18 +20,18 @@ public class DashboardService {
 
 	final DashboardRepository dashboardRepository;
 
-	public DashboardCountSummaryWebResponse getSummaryTotalCount(DashboardCountSummaryWebRequest webRequest) {
+	public DashboardCountSummaryWebResponse getSummaryTotalCount(LoginMemberDetail loginMemberDetail) {
 
-		final String userType = webRequest.userType();
-		final UUID companyId = webRequest.companyId();
-		final UUID memberId = webRequest.memberId();
+		final String userType = loginMemberDetail.userType();
+		final UUID companyId = loginMemberDetail.companyId();
+		final UUID memberId = loginMemberDetail.memberId();
 
-		if ("SYSTEMADMIN".equalsIgnoreCase(userType)) {
+		if ("ROLE_SYSTEM_ADMIN".equalsIgnoreCase(userType)) {
 			return getAdminSummary();
-		} else if (("DEVADMIN".equalsIgnoreCase(userType) || "CLIENTADMIN".equalsIgnoreCase(userType))
+		} else if (("ROLE_DEV_ADMIN".equalsIgnoreCase(userType) || "ROLE_CLIENT_ADMIN".equalsIgnoreCase(userType))
 			&& companyId != null) {
 			return getCompanyAdminSummary(companyId, userType);
-		} else if ("USER".equalsIgnoreCase(userType) && memberId != null) {
+		} else if ("ROLE_USER".equalsIgnoreCase(userType) && memberId != null) {
 			return getUserSummary(memberId);
 		} else {
 			throw new DashboardTypeNotFoundException(DashboardErrorType.TYPE_NOT_FOUND);
@@ -73,11 +72,11 @@ public class DashboardService {
 	}
 
 	private String extractCompanyAdminType(String userType) {
-		if (userType.equalsIgnoreCase("SYSTEMADMIN"))
+		if (userType.equalsIgnoreCase("ROLE_SYSTEM_ADMIN"))
 			return "system";
-		if (userType.equalsIgnoreCase("DEVADMIN"))
+		if (userType.equalsIgnoreCase("ROLE_DEV_ADMIN"))
 			return "dev";
-		if (userType.equalsIgnoreCase("CLIENTADMIN"))
+		if (userType.equalsIgnoreCase("ROLE_CLIENT_ADMIN"))
 			return "client";
 		return "user";
 	}

--- a/src/main/java/kr/mywork/domain/dashboard/service/dto/response/CompanyAdminProjectResponse.java
+++ b/src/main/java/kr/mywork/domain/dashboard/service/dto/response/CompanyAdminProjectResponse.java
@@ -1,0 +1,6 @@
+package kr.mywork.domain.dashboard.service.dto.response;
+
+import java.util.UUID;
+
+public record CompanyAdminProjectResponse(UUID projectId) {
+}

--- a/src/main/java/kr/mywork/domain/dashboard/service/dto/response/DashboardCountSummaryResponse.java
+++ b/src/main/java/kr/mywork/domain/dashboard/service/dto/response/DashboardCountSummaryResponse.java
@@ -1,0 +1,4 @@
+package kr.mywork.domain.dashboard.service.dto.response;
+
+public record DashboardCountSummaryResponse(long totalCount, long inProgressCount, long completedCount) {
+}

--- a/src/main/java/kr/mywork/domain/dashboard/service/errors/DashboardErrorCode.java
+++ b/src/main/java/kr/mywork/domain/dashboard/service/errors/DashboardErrorCode.java
@@ -1,0 +1,5 @@
+package kr.mywork.domain.dashboard.service.errors;
+
+public enum DashboardErrorCode {
+	ERROR_DASHBOARD01;
+}

--- a/src/main/java/kr/mywork/domain/dashboard/service/errors/DashboardErrorType.java
+++ b/src/main/java/kr/mywork/domain/dashboard/service/errors/DashboardErrorType.java
@@ -1,0 +1,15 @@
+package kr.mywork.domain.dashboard.service.errors;
+
+import kr.mywork.domain.company.errors.CompanyErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum DashboardErrorType {
+
+	TYPE_NOT_FOUND(DashboardErrorCode.ERROR_DASHBOARD01, "대시보드의 타입을 확인할 수 없습니다.");
+
+	private final DashboardErrorCode errorCode;
+	private final String message;
+}

--- a/src/main/java/kr/mywork/domain/dashboard/service/errors/DashboardException.java
+++ b/src/main/java/kr/mywork/domain/dashboard/service/errors/DashboardException.java
@@ -1,0 +1,14 @@
+package kr.mywork.domain.dashboard.service.errors;
+
+import kr.mywork.domain.company.errors.CompanyErrorType;
+import lombok.Getter;
+
+@Getter
+public class DashboardException extends RuntimeException {
+	private final DashboardErrorType errorType;
+
+	public DashboardException(final DashboardErrorType errorType) {
+		super(errorType.getMessage());
+		this.errorType = errorType;
+	}
+}

--- a/src/main/java/kr/mywork/domain/dashboard/service/errors/DashboardTypeNotFoundException.java
+++ b/src/main/java/kr/mywork/domain/dashboard/service/errors/DashboardTypeNotFoundException.java
@@ -1,0 +1,10 @@
+package kr.mywork.domain.dashboard.service.errors;
+
+import kr.mywork.domain.company.errors.CompanyErrorType;
+import kr.mywork.domain.company.errors.CompanyException;
+
+public class DashboardTypeNotFoundException extends DashboardException {
+	public DashboardTypeNotFoundException(final DashboardErrorType errorType) {
+		super(errorType);
+	}
+}

--- a/src/main/java/kr/mywork/domain/dashboard/service/repository/DashboardRepository.java
+++ b/src/main/java/kr/mywork/domain/dashboard/service/repository/DashboardRepository.java
@@ -1,0 +1,16 @@
+package kr.mywork.domain.dashboard.service.repository;
+
+import java.util.List;
+import java.util.UUID;
+
+import kr.mywork.domain.dashboard.service.dto.response.DashboardCountSummaryResponse;
+import kr.mywork.domain.project.model.ProjectAssign;
+import kr.mywork.domain.project.model.ProjectMember;
+
+public interface DashboardRepository {
+	DashboardCountSummaryResponse getAdminSummary();
+	DashboardCountSummaryResponse getCompanyAdminSummary(List<UUID> projectIds);
+	DashboardCountSummaryResponse getUserSummary(List<UUID> projectId);
+	List<ProjectAssign> getCompanyAdminProject (UUID companyId,String userType);
+	List<ProjectMember> getUserProject(UUID memberId);
+}

--- a/src/main/java/kr/mywork/infrastructure/dashboard/rdb/QueryDslDashboardRepository.java
+++ b/src/main/java/kr/mywork/infrastructure/dashboard/rdb/QueryDslDashboardRepository.java
@@ -1,0 +1,149 @@
+package kr.mywork.infrastructure.dashboard.rdb;
+
+import static kr.mywork.domain.project.model.QProject.*;
+import static kr.mywork.domain.project.model.QProjectAssign.*;
+import static kr.mywork.domain.project.model.QProjectMember.*;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import org.springframework.stereotype.Repository;
+
+import com.querydsl.core.Tuple;
+import com.querydsl.core.types.dsl.CaseBuilder;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+
+import kr.mywork.domain.dashboard.service.dto.response.DashboardCountSummaryResponse;
+import kr.mywork.domain.dashboard.service.errors.DashboardErrorType;
+import kr.mywork.domain.dashboard.service.errors.DashboardException;
+import kr.mywork.domain.dashboard.service.repository.DashboardRepository;
+import kr.mywork.domain.project.model.ProjectAssign;
+import kr.mywork.domain.project.model.ProjectMember;
+import lombok.RequiredArgsConstructor;
+
+
+@Repository
+@RequiredArgsConstructor
+public class QueryDslDashboardRepository implements DashboardRepository {
+
+	private final JPAQueryFactory queryFactory;
+
+	@Override
+	public DashboardCountSummaryResponse getAdminSummary() {
+		LocalDateTime now = LocalDateTime.now();
+
+		Tuple result = queryFactory.
+			select(
+				project.count(),
+				new CaseBuilder()
+					.when(project.startAt.before(now).and(project.endAt.after(now)))
+					.then(1L).otherwise(0L).sum()
+					.castToNum(Long.class),
+				new CaseBuilder()
+					.when(project.endAt.before(now))
+					.then(1L).otherwise(0L).sum()
+					.castToNum(Long.class)
+			)
+			.from(project)
+			.where(project.deleted.isFalse())
+			.fetchOne();
+
+		Long total = Optional.ofNullable(result.get(0, Long.class)).orElse(0L);
+		Long inProgress = Optional.ofNullable(result.get(1, Long.class)).orElse(0L);
+		Long completed = Optional.ofNullable(result.get(2, Long.class)).orElse(0L);
+
+		return new DashboardCountSummaryResponse(total, inProgress, completed);
+	}
+
+	@Override
+	public DashboardCountSummaryResponse getCompanyAdminSummary(List<UUID> projectIds) {
+		LocalDateTime now = LocalDateTime.now();
+
+		Tuple result = queryFactory
+			.select(
+				project.count(),
+				new CaseBuilder()
+					.when(project.startAt.before(now).and(project.endAt.after(now)))
+					.then(1L).otherwise(0L).sum()
+					.castToNum(Long.class),
+				new CaseBuilder()
+					.when(project.endAt.before(now))
+					.then(1L).otherwise(0L).sum()
+					.castToNum(Long.class)
+			)
+			.from(project)
+			.where(
+				project.id.in(projectIds),
+				project.deleted.isFalse()
+			)
+			.fetchOne();
+
+		Long total = Optional.ofNullable(result.get(0, Long.class)).orElse(0L);
+		Long inProgress = Optional.ofNullable(result.get(1, Long.class)).orElse(0L);
+		Long completed = Optional.ofNullable(result.get(2, Long.class)).orElse(0L);
+		return new DashboardCountSummaryResponse(total, inProgress, completed);
+	}
+
+	@Override
+	public DashboardCountSummaryResponse getUserSummary(List<UUID> projectIds) {
+		LocalDateTime now = LocalDateTime.now();
+
+		Tuple result = queryFactory
+			.select(
+				project.count(),
+				new CaseBuilder()
+					.when(project.startAt.before(now).and(project.endAt.after(now)))
+					.then(1L).otherwise(0L).sum()
+					.castToNum(Long.class),
+				new CaseBuilder()
+					.when(project.endAt.before(now))
+					.then(1L).otherwise(0L).sum()
+					.castToNum(Long.class)
+			)
+			.from(project)
+			.where(
+				project.id.in(projectIds),
+				project.deleted.isFalse()
+			)
+			.fetchOne();
+
+		Long total = Optional.ofNullable(result.get(0, Long.class)).orElse(0L);
+		Long inProgress = Optional.ofNullable(result.get(1, Long.class)).orElse(0L);
+		Long completed = Optional.ofNullable(result.get(2, Long.class)).orElse(0L);
+		return new DashboardCountSummaryResponse(total, inProgress, completed);
+	}
+
+	@Override
+	public List<ProjectAssign> getCompanyAdminProject(UUID companyId, String userType) {
+		if("dev".equals(userType)) {
+			return getDevCompanyProjects(companyId);
+		}else if ("client".equals(userType)) {
+			return getClientCompanyProjects(companyId);
+		} else {
+			throw new DashboardException(DashboardErrorType.TYPE_NOT_FOUND);
+		}
+	}
+
+	@Override
+	public List<ProjectMember> getUserProject(UUID memberId) {
+		return queryFactory
+			.selectFrom(projectMember)
+			.where(projectMember.memberId.eq(memberId))
+			.fetch();
+	}
+
+	private List<ProjectAssign> getDevCompanyProjects(UUID devCompanyId) {
+		return queryFactory
+			.selectFrom(projectAssign)
+			.where(projectAssign.devCompanyId.eq(devCompanyId))
+			.fetch();
+	}
+	private List<ProjectAssign> getClientCompanyProjects(UUID clientCompanyId) {
+		return queryFactory
+			.selectFrom(projectAssign)
+			.where(projectAssign.clientCompanyId.eq(clientCompanyId))
+			.fetch();
+	}
+}

--- a/src/main/java/kr/mywork/interfaces/dashboard/controller/DashboardController.java
+++ b/src/main/java/kr/mywork/interfaces/dashboard/controller/DashboardController.java
@@ -1,0 +1,34 @@
+package kr.mywork.interfaces.dashboard.controller;
+
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import kr.mywork.common.api.support.response.ApiResponse;
+import kr.mywork.domain.dashboard.service.DashboardService;
+import kr.mywork.interfaces.dashboard.controller.dto.request.DashboardCountSummaryWebRequest;
+import kr.mywork.interfaces.dashboard.controller.dto.response.DashboardCountSummaryWebResponse;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/dashboard")
+@Validated
+public class DashboardController {
+
+	private final DashboardService dashboardService;
+
+	@GetMapping("/totalSummery")
+	public ApiResponse<DashboardCountSummaryWebResponse> getDashboardTotalCount(
+		@RequestBody DashboardCountSummaryWebRequest dashboardCountSummaryWebRequest) {
+
+		final DashboardCountSummaryWebResponse dashboardCountSummaryWebResponse = dashboardService.getSummaryTotalCount(
+			dashboardCountSummaryWebRequest);
+
+		return ApiResponse.success(dashboardCountSummaryWebResponse);
+
+	}
+
+}

--- a/src/main/java/kr/mywork/interfaces/dashboard/controller/DashboardController.java
+++ b/src/main/java/kr/mywork/interfaces/dashboard/controller/DashboardController.java
@@ -1,16 +1,15 @@
 package kr.mywork.interfaces.dashboard.controller;
 
-import org.springframework.validation.annotation.Validated;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
-
 import kr.mywork.common.api.support.response.ApiResponse;
+import kr.mywork.common.auth.components.annotation.LoginMember;
+import kr.mywork.common.auth.components.dto.LoginMemberDetail;
 import kr.mywork.domain.dashboard.service.DashboardService;
-import kr.mywork.interfaces.dashboard.controller.dto.request.DashboardCountSummaryWebRequest;
 import kr.mywork.interfaces.dashboard.controller.dto.response.DashboardCountSummaryWebResponse;
 import lombok.RequiredArgsConstructor;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequiredArgsConstructor
@@ -22,10 +21,10 @@ public class DashboardController {
 
 	@GetMapping("/totalSummery")
 	public ApiResponse<DashboardCountSummaryWebResponse> getDashboardTotalCount(
-		@RequestBody DashboardCountSummaryWebRequest dashboardCountSummaryWebRequest) {
+			@LoginMember LoginMemberDetail loginMemberDetail) {
 
 		final DashboardCountSummaryWebResponse dashboardCountSummaryWebResponse = dashboardService.getSummaryTotalCount(
-			dashboardCountSummaryWebRequest);
+				loginMemberDetail);
 
 		return ApiResponse.success(dashboardCountSummaryWebResponse);
 

--- a/src/main/java/kr/mywork/interfaces/dashboard/controller/dto/request/DashboardCountSummaryWebRequest.java
+++ b/src/main/java/kr/mywork/interfaces/dashboard/controller/dto/request/DashboardCountSummaryWebRequest.java
@@ -1,0 +1,6 @@
+package kr.mywork.interfaces.dashboard.controller.dto.request;
+
+import java.util.UUID;
+
+public record DashboardCountSummaryWebRequest(String userType , UUID companyId, UUID memberId) {
+}

--- a/src/main/java/kr/mywork/interfaces/dashboard/controller/dto/response/DashboardCountSummaryWebResponse.java
+++ b/src/main/java/kr/mywork/interfaces/dashboard/controller/dto/response/DashboardCountSummaryWebResponse.java
@@ -1,0 +1,14 @@
+package kr.mywork.interfaces.dashboard.controller.dto.response;
+
+import kr.mywork.domain.dashboard.service.dto.response.DashboardCountSummaryResponse;
+
+public record DashboardCountSummaryWebResponse(long totalCount, long inProgressCount, long completedCount) {
+
+
+	public static DashboardCountSummaryWebResponse from(DashboardCountSummaryResponse response) {
+		return new DashboardCountSummaryWebResponse(
+			response.totalCount(), response.inProgressCount(), response.completedCount()
+		);
+	}
+
+}

--- a/src/main/java/kr/mywork/interfaces/dashboard/controller/errors/handler/DashboardControllerAdvice.java
+++ b/src/main/java/kr/mywork/interfaces/dashboard/controller/errors/handler/DashboardControllerAdvice.java
@@ -1,0 +1,23 @@
+package kr.mywork.interfaces.dashboard.controller.errors.handler;
+
+import kr.mywork.common.api.support.response.ApiResponse;
+import kr.mywork.domain.dashboard.service.errors.DashboardErrorType;
+import kr.mywork.domain.dashboard.service.errors.DashboardException;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@Order(Ordered.LOWEST_PRECEDENCE - 1)
+@RestControllerAdvice
+public class DashboardControllerAdvice {
+
+	@ExceptionHandler(DashboardException.class)
+	public ResponseEntity<ApiResponse<?>> handlePostException(DashboardException exception) {
+		final DashboardErrorType errorType = exception.getErrorType();
+
+		return ResponseEntity.badRequest().body(
+			ApiResponse.error(errorType.getErrorCode().name(), errorType.getMessage()));
+	}
+}

--- a/src/test/java/kr/mywork/docs/DashboardDocumentationTest.java
+++ b/src/test/java/kr/mywork/docs/DashboardDocumentationTest.java
@@ -1,0 +1,70 @@
+package kr.mywork.docs;
+
+import static com.epages.restdocs.apispec.MockMvcRestDocumentationWrapper.*;
+import static com.epages.restdocs.apispec.ResourceDocumentation.*;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.*;
+import static org.springframework.restdocs.payload.PayloadDocumentation.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.restdocs.payload.JsonFieldType;
+import org.springframework.test.context.jdbc.Sql;
+import org.springframework.test.web.servlet.ResultActions;
+
+import com.epages.restdocs.apispec.ResourceSnippet;
+import com.epages.restdocs.apispec.ResourceSnippetParameters;
+
+import kr.mywork.common.api.support.response.ResultType;
+import kr.mywork.interfaces.dashboard.controller.dto.request.DashboardCountSummaryWebRequest;
+
+public class DashboardDocumentationTest extends RestDocsDocumentation {
+
+	@Test
+	@DisplayName("대쉬보드 summery total 갯수 조회")
+	@Sql("classpath:sql/dashboard-summery-count.sql")
+	void 대쉬보드_써머리_총갯수_조회_성공() throws Exception {
+		// given
+		final String accessToken = createSystemAccessToken();
+		final DashboardCountSummaryWebRequest dashboardCountSummaryWebRequest =
+			new DashboardCountSummaryWebRequest("SYSTEMADMIN",null,null);
+		final String requestBody = objectMapper.writeValueAsString(dashboardCountSummaryWebRequest);
+
+		// when
+		ResultActions result = mockMvc.perform(
+			get("/api/dashboard/totalSummery")
+				.content(requestBody)
+				.contentType(MediaType.APPLICATION_JSON)
+				.header(HttpHeaders.AUTHORIZATION, toBearerAuthorizationHeader(accessToken)));
+
+		//then
+		result.andExpectAll(
+			status().isOk(),
+			jsonPath("$.result").value(ResultType.SUCCESS.name()),
+			jsonPath("$.data").exists(),
+			jsonPath("$.error").doesNotExist()
+		).andDo(document("dashboard-get-count-summery-success", TotalCountSummerySuccessResource()));
+	}
+
+	private ResourceSnippet TotalCountSummerySuccessResource() {
+		return resource(
+			ResourceSnippetParameters.builder()
+				.tag("Dashboard API")
+				.summary("대시보드 서머리 조회 API")
+				.description("(모든,진행중,완료) 프로젝트 갯수를 보여준다")
+				.requestHeaders(
+					headerWithName(HttpHeaders.CONTENT_TYPE).description("컨텐츠 타입"),
+					headerWithName(HttpHeaders.AUTHORIZATION).description("엑세스 토큰"))
+				.responseFields(
+					fieldWithPath("result").type(JsonFieldType.STRING).description("응답 결과"),
+					fieldWithPath("data.totalCount").type(JsonFieldType.NUMBER).description("모든 프로젝트 갯수"),
+					fieldWithPath("data.inProgressCount").type(JsonFieldType.NUMBER).description("진행중인 프로젝트 갯수"),
+					fieldWithPath("data.completedCount").type(JsonFieldType.NUMBER).description("완료된 프로젝트 갯수"),
+					fieldWithPath("error").type(JsonFieldType.NULL).description("에러 정보"))
+				.build()
+		);
+	}
+
+}

--- a/src/test/resources/sql/dashboard-summery-count.sql
+++ b/src/test/resources/sql/dashboard-summery-count.sql
@@ -1,0 +1,55 @@
+
+INSERT INTO project (id, name, start_at, end_at, step, created_at, modified_at, detail, deleted)
+VALUES (UUID_TO_BIN('01975d7f-052c-7d8f-819b-9a08f322ead3'),
+        '개발 프로젝트',
+        NOW(),
+        NOW(),
+        'IN_PROGRESS',
+        NOW(),
+        NOW(),
+        '고객사의 웹페이지를 구성해주는 프로젝트입니다',
+        0);
+
+INSERT INTO project (id, name, start_at, end_at, step, created_at, modified_at, detail, deleted)
+VALUES (UUID_TO_BIN('01975d82-e17b-71a9-801d-b941addc79d2'),
+        '개발 프로젝트',
+        NOW(),
+        NOW(),
+        'IN_PROGRESS',
+        NOW(),
+        NOW(),
+        '고객사의 웹페이지를 구성해주는 프로젝트입니다',
+        0);
+
+INSERT INTO project (id, name, start_at, end_at, step, created_at, modified_at, detail, deleted)
+VALUES (UUID_TO_BIN('01975d82-e17b-73d6-aeca-628437d67f14'),
+        '개발 프로젝트',
+        NOW(),
+        NOW(),
+        'IN_PROGRESS',
+        NOW(),
+        NOW(),
+        '고객사의 웹페이지를 구성해주는 프로젝트입니다',
+        0);
+
+INSERT INTO project (id, name, start_at, end_at, step, created_at, modified_at, detail, deleted)
+VALUES (UUID_TO_BIN('01975d82-e17b-7f59-b862-0354e1fbc8e3'),
+        '개발 프로젝트',
+        NOW(),
+        NOW(),
+        'IN_PROGRESS',
+        NOW(),
+        NOW(),
+        '고객사의 웹페이지를 구성해주는 프로젝트입니다',
+        0);
+
+INSERT INTO project (id, name, start_at, end_at, step, created_at, modified_at, detail, deleted)
+VALUES (UUID_TO_BIN('01975d82-e17b-7018-a8d2-82615bd41a5e'),
+        '개발 프로젝트',
+        NOW(),
+        NOW(),
+        'IN_PROGRESS',
+        NOW(),
+        NOW(),
+        '고객사의 웹페이지를 구성해주는 프로젝트입니다',
+        0);


### PR DESCRIPTION
## 📌 개요

- 대시보드 써머리 조회 API

## 🛠️ 변경 사항
- 대시보드 써머리 조회 API

## ✅ 주요 체크 포인트

- [ ] 케이스별 테스트 ( 유저, (dev,client) admin , systemAdmin
- [ ] 대시보드 갯수

## 🔁 테스트 결과
-통합테스 및 포스트맨 

![image](https://github.com/user-attachments/assets/0920bd1a-bccb-4353-a44f-83bdaa5a0dd6)
![image](https://github.com/user-attachments/assets/1dae3a13-1174-44f5-aa73-fcbe010b95de)
![image](https://github.com/user-attachments/assets/460d0349-c0c1-4ad8-92e3-340be67440fb)
![image](https://github.com/user-attachments/assets/f395486c-9662-4639-b3a7-305f27bc1628)


## 🔗 연관된 이슈
#206 