### PR TITLE
[fix] 내 직원 목록을 조회하는 API 수정

### DIFF
--- a/src/main/java/kr/mywork/common/auth/components/dto/LoginMemberDetail.java
+++ b/src/main/java/kr/mywork/common/auth/components/dto/LoginMemberDetail.java
@@ -2,5 +2,5 @@ package kr.mywork.common.auth.components.dto;
 
 import java.util.UUID;
 
-public record LoginMemberDetail(UUID memberId, String memberName, UUID companyId, String companyName,String userType) {
+public record LoginMemberDetail(UUID memberId, String memberName, UUID companyId, String companyName,String roleName) {
 }

--- a/src/main/java/kr/mywork/domain/dashboard/service/DashboardService.java
+++ b/src/main/java/kr/mywork/domain/dashboard/service/DashboardService.java
@@ -22,7 +22,7 @@ public class DashboardService {
 
 	public DashboardCountSummaryWebResponse getSummaryTotalCount(LoginMemberDetail loginMemberDetail) {
 
-		final String userType = loginMemberDetail.userType();
+		final String userType = loginMemberDetail.roleName();
 		final UUID companyId = loginMemberDetail.companyId();
 		final UUID memberId = loginMemberDetail.memberId();
 

--- a/src/main/java/kr/mywork/domain/member/model/MemberRole.java
+++ b/src/main/java/kr/mywork/domain/member/model/MemberRole.java
@@ -1,11 +1,11 @@
 package kr.mywork.domain.member.model;
 
-import java.util.Arrays;
-
 import kr.mywork.domain.member.errors.MemberErrorType;
 import kr.mywork.domain.member.errors.MemberTypeNotFoundException;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
+
+import java.util.Arrays;
 
 @Getter
 @RequiredArgsConstructor
@@ -30,5 +30,9 @@ public enum MemberRole {
 			.filter(memberRole -> memberRole.name().equals(value))
 			.findAny()
 			.orElseThrow(() -> new MemberTypeNotFoundException(MemberErrorType.TYPE_NOT_FOUND));
+	}
+
+	public boolean isSameRoleName(final String roleName) {
+		return this.roleName.equals(roleName);
 	}
 }

--- a/src/main/java/kr/mywork/domain/member/service/MemberService.java
+++ b/src/main/java/kr/mywork/domain/member/service/MemberService.java
@@ -1,21 +1,7 @@
 package kr.mywork.domain.member.service;
 
-import java.time.format.DateTimeFormatter;
-import java.util.List;
-import java.util.UUID;
-import java.util.stream.Collectors;
-
-import org.springframework.beans.factory.annotation.Value;
-import org.springframework.security.crypto.password.PasswordEncoder;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
-
 import kr.mywork.domain.company.service.dto.response.MemberDetailResponse;
-import kr.mywork.domain.member.errors.EmailAlreadyExistsException;
-import kr.mywork.domain.member.errors.MemberErrorType;
-import kr.mywork.domain.member.errors.MemberIdNotFoundException;
-import kr.mywork.domain.member.errors.MemberNotFoundException;
-import kr.mywork.domain.member.errors.PasswordFailException;
+import kr.mywork.domain.member.errors.*;
 import kr.mywork.domain.member.model.Member;
 import kr.mywork.domain.member.repository.MemberRepository;
 import kr.mywork.domain.member.service.dto.request.MemberCreateRequest;
@@ -24,6 +10,15 @@ import kr.mywork.domain.member.service.dto.response.CompanyMemberResponse;
 import kr.mywork.domain.member.service.dto.response.MemberSelectResponse;
 import kr.mywork.interfaces.member.controller.dto.request.ResetPasswordWebRequest;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+import java.util.UUID;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -105,9 +100,8 @@ public class MemberService {
 	}
 
 	@Transactional
-	public List<MemberSelectResponse> findMembersBySearchWithPaging(final int page, String keyword,
-		String keywordType,UUID companyId) {
-
+	public List<MemberSelectResponse> findMembersBySearchWithPaging(final int page, final String keyword,
+		final String keywordType, final UUID companyId) {
 		return memberRepository.findMembersBySearchWithPaging(page, memberPageSize, keyword, keywordType,companyId);
 	}
 

--- a/src/main/java/kr/mywork/infrastructure/member/rdb/QueryDslMemberRepository.java
+++ b/src/main/java/kr/mywork/infrastructure/member/rdb/QueryDslMemberRepository.java
@@ -1,24 +1,22 @@
 package kr.mywork.infrastructure.member.rdb;
 
-import static kr.mywork.domain.company.model.QCompany.company;
-import static kr.mywork.domain.member.model.QMember.member;
-
-import java.util.List;
-import java.util.Optional;
-import java.util.UUID;
-
-import org.springframework.stereotype.Repository;
-
 import com.querydsl.core.BooleanBuilder;
 import com.querydsl.core.types.Projections;
 import com.querydsl.jpa.impl.JPAQueryFactory;
-
 import kr.mywork.domain.company.service.dto.response.MemberDetailResponse;
 import kr.mywork.domain.member.model.Member;
 import kr.mywork.domain.member.repository.MemberRepository;
 import kr.mywork.domain.member.service.dto.response.MemberSelectResponse;
 import kr.mywork.domain.project.model.QProjectMember;
 import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import static kr.mywork.domain.company.model.QCompany.company;
+import static kr.mywork.domain.member.model.QMember.member;
 
 @Repository
 @RequiredArgsConstructor
@@ -120,8 +118,6 @@ public class QueryDslMemberRepository implements MemberRepository {
 		BooleanBuilder builder = new BooleanBuilder();
 		final int offset = (page - 1) * memberPageSize;
 
-
-
 		builder.and(member.deleted.eq(false));
 		if (companyId != null) {builder.and(member.companyId.eq(companyId));}
 
@@ -151,6 +147,7 @@ public class QueryDslMemberRepository implements MemberRepository {
 			.from(member)
 			.leftJoin(company).on(member.companyId.eq(company.id))
 			.where(builder)
+			.orderBy(member.createdAt.desc())
 			.offset(offset)
 			.limit(memberPageSize)
 			.fetch();

--- a/src/test/java/kr/mywork/docs/MemberDocumentationTest.java
+++ b/src/test/java/kr/mywork/docs/MemberDocumentationTest.java
@@ -1,19 +1,13 @@
 package kr.mywork.docs;
 
-import static com.epages.restdocs.apispec.ResourceDocumentation.headerWithName;
-import static com.epages.restdocs.apispec.ResourceDocumentation.resource;
-import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
-import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.delete;
-import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
-import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
-import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.put;
-import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
-
-import java.time.LocalDateTime;
-import java.util.UUID;
-
+import com.epages.restdocs.apispec.MockMvcRestDocumentationWrapper;
+import com.epages.restdocs.apispec.ResourceSnippet;
+import com.epages.restdocs.apispec.ResourceSnippetParameters;
+import kr.mywork.common.api.support.response.ResultType;
+import kr.mywork.interfaces.member.controller.dto.request.MemberCreateWebRequest;
+import kr.mywork.interfaces.member.controller.dto.request.MemberDeleteWebRequest;
+import kr.mywork.interfaces.member.controller.dto.request.MemberUpdateWebRequest;
+import kr.mywork.interfaces.member.controller.dto.request.ResetPasswordWebRequest;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpHeaders;
@@ -22,15 +16,16 @@ import org.springframework.restdocs.payload.JsonFieldType;
 import org.springframework.test.context.jdbc.Sql;
 import org.springframework.test.web.servlet.ResultActions;
 
-import com.epages.restdocs.apispec.MockMvcRestDocumentationWrapper;
-import com.epages.restdocs.apispec.ResourceSnippet;
-import com.epages.restdocs.apispec.ResourceSnippetParameters;
+import java.time.LocalDateTime;
+import java.util.UUID;
 
-import kr.mywork.common.api.support.response.ResultType;
-import kr.mywork.interfaces.member.controller.dto.request.MemberCreateWebRequest;
-import kr.mywork.interfaces.member.controller.dto.request.MemberDeleteWebRequest;
-import kr.mywork.interfaces.member.controller.dto.request.MemberUpdateWebRequest;
-import kr.mywork.interfaces.member.controller.dto.request.ResetPasswordWebRequest;
+import static com.epages.restdocs.apispec.ResourceDocumentation.headerWithName;
+import static com.epages.restdocs.apispec.ResourceDocumentation.resource;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.*;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 public class MemberDocumentationTest extends RestDocsDocumentation {
 
@@ -167,14 +162,12 @@ public class MemberDocumentationTest extends RestDocsDocumentation {
 	@Sql("classpath:sql/member-search.sql")
 	void 멤버_조회_성공() throws Exception {
 		//given
-		final String accessToken = createDevAdminAccessToken();
+		final String accessToken = createSystemAccessToken();
 
 		//when
 		final ResultActions result = mockMvc.perform(
 			get("/api/member")
 				.param("page","1")
-				.param("keyword","기획팀")
-				.param("keywordType","DEPARTMENT")
 				.contentType(MediaType.APPLICATION_JSON)
 				.header(HttpHeaders.AUTHORIZATION, toBearerAuthorizationHeader(accessToken)));
 		//then


### PR DESCRIPTION
## 📌 개요

- 내 직원 목록만 조회하도록 수정

## 🛠️ 변경 사항
- 기존 파라미터로 받던 companyId 를 @LoginMember 로그인정보를 통해서 가져옴.
- 쿼리 정렬기준을 createdAt 으로 변경 ( UUID 7버전이 아닌 데이터가 있어서 )

## ✅ 주요 체크 포인트

- [ ] 리스트가 정상 노출되는지 확인
- [ ] 테스트 코드가 돌아가는 지 확인
## 🔁 테스트 결과
<img width="675" alt="image" src="https://github.com/user-attachments/assets/301433f9-95eb-46f2-b3ee-04d620e5b048" />

![image](https://github.com/user-attachments/assets/c666b9a5-6f33-4b14-8291-71434f43fea6)

## 🔗 연관된 이슈

- 해당 PR 과 연관된 이슈를 연결해 주세요.
#41 