### PR TITLE
[feat] 체크리스트가 없는 경우에도 프로젝트 단계 출력

### DIFF
--- a/src/main/java/kr/mywork/infrastructure/project_checklist/rdb/QueryDslProjectCheckListRepository.java
+++ b/src/main/java/kr/mywork/infrastructure/project_checklist/rdb/QueryDslProjectCheckListRepository.java
@@ -44,16 +44,16 @@ public class QueryDslProjectCheckListRepository implements ProjectCheckListRepos
 	public List<ProjectStepCheckListCountResponse> findProgressCountGroupByProjectStepIdAndApproval(
 		final Collection<UUID> projectStepIds, final String approval) {
 		return queryFactory.select(Projections.constructor(ProjectStepCheckListCountResponse.class,
-				projectCheckList.projectStepId,
+				projectStep.id,
 				count(projectCheckList.id),
 				projectStep.orderNum))
-			.from(projectCheckList)
-			.join(projectStep).on(projectCheckList.projectStepId.eq(projectStep.id))
-			.where(
-				projectCheckList.deleted.isFalse(),
-				eqApproval(approval),
-				projectCheckList.projectStepId.in(projectStepIds))
-			.groupBy(projectCheckList.projectStepId, projectStep.orderNum)
+			.from(projectStep)
+			.leftJoin(projectCheckList)
+				.on(projectCheckList.projectStepId.eq(projectStep.id)
+					.and(projectCheckList.deleted.isFalse())
+					.and(eqApproval(approval)))
+			.where(projectStep.id.in(projectStepIds))
+			.groupBy(projectStep.id, projectStep.orderNum)
 			.orderBy(projectStep.orderNum.asc())
 			.fetch();
 	}


### PR DESCRIPTION
## 📌 개요

- 체크리스트가 없는 경우에도 프로젝트 단계 출력

## 🛠️ 변경 사항

- 기존 inner join 문 -> left join 으로 변경


## ✅ 주요 체크 포인트

- [ ] 결재 관리에서 프로젝트 단계 목록들의 정상 출력 여부 확인


## 🔁 테스트 결과

- 로컬 테스트 결과 정상 동작 확인

![image](https://github.com/user-attachments/assets/6a7d8c68-cac8-4a21-9d73-42a157727fc7)


![image](https://github.com/user-attachments/assets/4bbaa793-c8fb-4b2d-9cd9-cd9299814561)


## 🔗 연관된 이슈

- 없음

## 📑 레퍼런스

- 없음