### PR TITLE
[build] 스크립트 내부 사용자 로그 쓰기 권한 추가

### DIFF
--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -12,5 +12,7 @@ mkdir -p ../log/info
 mkdir -p ../log/warn
 mkdir -p ../log/error
 
+sudo chown -R ec2-user:ec2-user ../log
+
 # 백그라운드에서 실행
 nohup java -jar $JAR_PATH --spring.profiles.active=prod --spring.config.location=file:/home/ec2-user/config/application-prod.yml > /home/ec2-user/deploy/nohup.out 2>&1 &


### PR DESCRIPTION
## 📌 개요

- 스크립트 내부 사용자 로그 쓰기 권한 추가

## 🛠️ 변경 사항

- 스크립트 내부 사용자 로그 쓰기 권한 추가

```bash
#!/bin/bash
JAR_PATH=/home/ec2-user/deploy/mywork-be-0.0.1-SNAPSHOT.jar
APP_NAME=mywork-be-0.0.1-SNAPSHOT

# 기존 프로세스 종료
PID=$(pgrep -f $APP_NAME)
if [ -n "$PID" ]; then
  kill -9 $PID
fi

mkdir -p ../log/info
mkdir -p ../log/warn
mkdir -p ../log/error

sudo chown -R ec2-user:ec2-user ../log # 이 부분

# 백그라운드에서 실행
nohup java -jar $JAR_PATH --spring.profiles.active=prod --spring.config.location=file:/home/ec2-user/config/application-prod.yml > /home/ec2-user/deploy/nohup.out 2>&1 &

```

## ✅ 주요 체크 포인트

- [ ] 배포 자동화 정상 동작 확인 필요


## 🔁 테스트 결과

- 개발 환경에서 1차 확인

## 🔗 연관된 이슈


## 📑 레퍼런스

- 없음