### PR TITLE
Feature #260

### DIFF
--- a/src/main/java/kr/mywork/domain/notification/errors/NotificationErrorCode.java
+++ b/src/main/java/kr/mywork/domain/notification/errors/NotificationErrorCode.java
@@ -1,0 +1,5 @@
+package kr.mywork.domain.notification.errors;
+
+public enum NotificationErrorCode {
+	ERROR_NOTIFICATION_TYPE01;
+}

--- a/src/main/java/kr/mywork/domain/notification/errors/NotificationErrorType.java
+++ b/src/main/java/kr/mywork/domain/notification/errors/NotificationErrorType.java
@@ -1,0 +1,13 @@
+package kr.mywork.domain.notification.errors;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum NotificationErrorType {
+	NOTIFICATION_NOT_FOUND(NotificationErrorCode.ERROR_NOTIFICATION_TYPE01, "존재하지 않는 알림입니다.");
+
+	private final NotificationErrorCode errorCode;
+	private final String message;
+}

--- a/src/main/java/kr/mywork/domain/notification/errors/NotificationException.java
+++ b/src/main/java/kr/mywork/domain/notification/errors/NotificationException.java
@@ -1,0 +1,13 @@
+package kr.mywork.domain.notification.errors;
+
+import lombok.Getter;
+
+@Getter
+public abstract class NotificationException extends RuntimeException {
+	private final NotificationErrorType errorType;
+
+	public NotificationException(final NotificationErrorType errorType) {
+		super(errorType.getMessage());
+		this.errorType = errorType;
+	}
+}

--- a/src/main/java/kr/mywork/domain/notification/errors/TargetTypeNotFoundException.java
+++ b/src/main/java/kr/mywork/domain/notification/errors/TargetTypeNotFoundException.java
@@ -1,0 +1,10 @@
+package kr.mywork.domain.notification.errors;
+
+import kr.mywork.domain.activityLog.errors.ActivityLogErrorType;
+import kr.mywork.domain.activityLog.errors.ActivityLogException;
+
+public class TargetTypeNotFoundException extends NotificationException {
+	public TargetTypeNotFoundException(final NotificationErrorType errorType) {
+		super(errorType);
+	}
+}

--- a/src/main/java/kr/mywork/domain/notification/model/Notification.java
+++ b/src/main/java/kr/mywork/domain/notification/model/Notification.java
@@ -1,0 +1,86 @@
+package kr.mywork.domain.notification.model;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+import org.hibernate.annotations.CreationTimestamp;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.Id;
+import kr.mywork.common.rdb.id.UnixTimeOrderedUuidGeneratedValue;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class Notification {
+
+	@Id
+	@UnixTimeOrderedUuidGeneratedValue
+	private UUID id;
+
+	// 수신자 정보
+	private UUID receiverMemberId;
+	private String receiverMemberName;
+
+	// 알림 내용
+	private String notificationContent;
+
+	// 액션자 정보
+	private String actorName;
+	private UUID actorId;
+
+	// 타겟 정보
+	@Enumerated(EnumType.STRING)
+	private TargetType targetType;
+	private UUID targetId;
+
+	// 액션 정보
+	@Enumerated(EnumType.STRING)
+	private NotificationActionType actionType;
+	private LocalDateTime actionDate;
+
+	// 상태 관리
+	private Boolean isRead;
+	private Boolean isTargetDeleted;
+
+	private UUID projectId;
+	private UUID projectStepId;
+
+	// 시간 정보
+	@CreationTimestamp
+	private LocalDateTime createdAt;
+
+	public Notification(UUID receiverMemberId, String receiverMemberName,
+		String notificationContent, String actorName, UUID actorId, TargetType targetType, UUID targetId,
+		NotificationActionType actionType, LocalDateTime actionDate, UUID projectId, UUID projectStepId) {
+		this.receiverMemberId = receiverMemberId;
+		this.receiverMemberName = receiverMemberName;
+		this.notificationContent = notificationContent;
+		this.actorName = actorName;
+		this.actorId = actorId;
+		this.targetType = targetType;
+		this.targetId = targetId;
+		this.actionType = actionType;
+		this.actionDate = actionDate;
+		this.projectId = projectId;
+		this.projectStepId = projectStepId;
+		this.isRead = false;
+		this.isTargetDeleted = false;
+	}
+
+	// 읽음 처리
+	public void markAsRead() {
+		this.isRead = true;
+	}
+
+	// 타겟 삭제 처리
+	public void markTargetAsDeleted() {
+		this.isTargetDeleted = true;
+	}
+}

--- a/src/main/java/kr/mywork/domain/notification/model/NotificationActionType.java
+++ b/src/main/java/kr/mywork/domain/notification/model/NotificationActionType.java
@@ -1,0 +1,5 @@
+package kr.mywork.domain.notification.model;
+
+public enum NotificationActionType {
+	CREATE, MODIFY, DELETE, REJECTED, APPROVED, REQUEST_CHANGES;
+}

--- a/src/main/java/kr/mywork/domain/notification/model/NotificationTitle.java
+++ b/src/main/java/kr/mywork/domain/notification/model/NotificationTitle.java
@@ -1,0 +1,15 @@
+package kr.mywork.domain.notification.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor
+@Getter
+public enum NotificationTitle {
+	POST_APPROVE("게시글 승인 응답"),
+	PROJECT_CHECK_LIST_APPROVED("체크리스트 승인 응답"),
+	PROJECT_CHECK_LIST_REJECTED("체크리스트 거절 응답"),
+	PROJECT_CHECK_LIST_REQUEST_CHANGES("체크리스트 수정 요청 응답");
+
+	private final String title;
+}

--- a/src/main/java/kr/mywork/domain/notification/model/TargetType.java
+++ b/src/main/java/kr/mywork/domain/notification/model/TargetType.java
@@ -1,0 +1,5 @@
+package kr.mywork.domain.notification.model;
+
+public enum TargetType {
+	POST, REVIEW, PROJECT_CHECK_LIST, MEMBER, COMPANY, PROJECT, PROJECT_STEP, PROJECT_MEMBER, UNKNOWN;
+}

--- a/src/main/java/kr/mywork/domain/notification/repository/NotificationRepository.java
+++ b/src/main/java/kr/mywork/domain/notification/repository/NotificationRepository.java
@@ -1,0 +1,15 @@
+package kr.mywork.domain.notification.repository;
+
+import java.util.List;
+import java.util.UUID;
+
+import kr.mywork.domain.notification.model.Notification;
+import kr.mywork.domain.notification.service.dto.response.NotificationSelectResponse;
+
+public interface NotificationRepository {
+	Notification save(Notification notification);
+
+	List<NotificationSelectResponse> findByConditionWithPaging(int page, Boolean isRead, UUID memberId);
+
+	Notification findById(UUID id);
+}

--- a/src/main/java/kr/mywork/domain/notification/service/NotificationService.java
+++ b/src/main/java/kr/mywork/domain/notification/service/NotificationService.java
@@ -1,0 +1,44 @@
+package kr.mywork.domain.notification.service;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import jakarta.validation.constraints.Min;
+import kr.mywork.domain.notification.model.Notification;
+import kr.mywork.domain.notification.model.NotificationActionType;
+import kr.mywork.domain.notification.model.TargetType;
+import kr.mywork.domain.notification.repository.NotificationRepository;
+import kr.mywork.domain.notification.service.dto.request.NotificationReadRequest;
+import kr.mywork.domain.notification.service.dto.response.NotificationReadResponse;
+import kr.mywork.domain.notification.service.dto.response.NotificationSelectResponse;
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class NotificationService {
+
+	private final NotificationRepository notificationRepository;
+
+	public void save(UUID authorId, String authorName, String content, String actorName,
+		UUID actorId, TargetType targetType, UUID targetId, NotificationActionType notificationActionType, LocalDateTime modifiedAt, UUID projectId, UUID projectStepId) {
+
+		notificationRepository.save(new Notification(authorId, authorName, content, actorName, actorId, targetType, targetId, notificationActionType, modifiedAt, projectId, projectStepId));
+	}
+
+	public List<NotificationSelectResponse> findByConditionWithPaging(int page, Boolean isRead, UUID memberId) {
+
+		return notificationRepository.findByConditionWithPaging(page, isRead, memberId);
+	}
+
+	public NotificationReadResponse readNotification(NotificationReadRequest notificationReadRequest) {
+		Notification notification = notificationRepository.findById(notificationReadRequest.getId());
+
+		notification.markAsRead();
+		return new NotificationReadResponse(notification.getId());
+	}
+}

--- a/src/main/java/kr/mywork/domain/notification/service/dto/request/NotificationReadRequest.java
+++ b/src/main/java/kr/mywork/domain/notification/service/dto/request/NotificationReadRequest.java
@@ -1,0 +1,12 @@
+package kr.mywork.domain.notification.service.dto.request;
+
+import java.util.UUID;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor
+@Getter
+public class NotificationReadRequest {
+	private UUID id;
+}

--- a/src/main/java/kr/mywork/domain/notification/service/dto/response/NotificationReadResponse.java
+++ b/src/main/java/kr/mywork/domain/notification/service/dto/response/NotificationReadResponse.java
@@ -1,0 +1,12 @@
+package kr.mywork.domain.notification.service.dto.response;
+
+import java.util.UUID;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor
+@Getter
+public class NotificationReadResponse {
+	private final UUID id;
+}

--- a/src/main/java/kr/mywork/domain/notification/service/dto/response/NotificationSelectResponse.java
+++ b/src/main/java/kr/mywork/domain/notification/service/dto/response/NotificationSelectResponse.java
@@ -1,0 +1,42 @@
+package kr.mywork.domain.notification.service.dto.response;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+
+import kr.mywork.domain.notification.model.NotificationActionType;
+import kr.mywork.domain.notification.model.TargetType;
+import lombok.Getter;
+
+@Getter
+public class NotificationSelectResponse {
+
+	private final UUID id;
+	private final UUID actorId;
+	private final String actorName;
+	private final String actionType;
+	private final String targetType;
+	private final UUID targetId;
+	private final String content;
+	private final UUID projectId;
+	private final UUID projectStepId;
+
+	@JsonFormat(pattern = "yyyy-MM-dd HH:mm")
+	private final LocalDateTime actionTime;
+
+	public NotificationSelectResponse(UUID id, UUID actorId, String actorName, NotificationActionType actionType,
+		TargetType targetType, UUID targetId, String content,
+		UUID projectId, UUID projectStepId, LocalDateTime actionTime) {
+		this.id = id;
+		this.actorId = actorId;
+		this.actorName = actorName;
+		this.actionType = actionType.name();
+		this.targetType = targetType.name();
+		this.targetId = targetId;
+		this.content = content;
+		this.projectId = projectId;
+		this.projectStepId = projectStepId;
+		this.actionTime = actionTime;
+	}
+}

--- a/src/main/java/kr/mywork/infrastructure/notification/rdb/JpaNotificationRepository.java
+++ b/src/main/java/kr/mywork/infrastructure/notification/rdb/JpaNotificationRepository.java
@@ -1,0 +1,10 @@
+package kr.mywork.infrastructure.notification.rdb;
+
+import java.util.UUID;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import kr.mywork.domain.notification.model.Notification;
+
+public interface JpaNotificationRepository extends JpaRepository<Notification, UUID> {
+}

--- a/src/main/java/kr/mywork/infrastructure/notification/rdb/QueryDslNotificationRepository.java
+++ b/src/main/java/kr/mywork/infrastructure/notification/rdb/QueryDslNotificationRepository.java
@@ -1,0 +1,78 @@
+package kr.mywork.infrastructure.notification.rdb;
+
+import java.util.List;
+import java.util.UUID;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Repository;
+
+import com.querydsl.core.types.Projections;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+
+import kr.mywork.domain.notification.errors.NotificationErrorType;
+import kr.mywork.domain.notification.errors.NotificationException;
+import kr.mywork.domain.notification.model.Notification;
+import kr.mywork.domain.notification.repository.NotificationRepository;
+import kr.mywork.domain.notification.service.dto.response.NotificationSelectResponse;
+import lombok.RequiredArgsConstructor;
+
+import static kr.mywork.domain.notification.model.QNotification.notification;
+
+@Repository
+@RequiredArgsConstructor
+public class QueryDslNotificationRepository implements NotificationRepository {
+	@Value("${post.page.size}")
+	private int postPageSize;
+
+	private final JpaNotificationRepository jpaNotificationRepository;
+	private final JPAQueryFactory queryFactory;
+
+	public Notification save(Notification notification) {
+		return jpaNotificationRepository.save(notification);
+	}
+
+ 	public Notification findById(UUID id) {
+		return jpaNotificationRepository.findById(id)
+			.orElseThrow(() -> new NotificationException(NotificationErrorType.NOTIFICATION_NOT_FOUND) {
+			});
+	}
+
+	@Override
+	public List<NotificationSelectResponse> findByConditionWithPaging(int page, Boolean isRead, UUID memberId) {
+
+		final int offset = (page - 1) * postPageSize;
+
+		return queryFactory
+			.select(Projections.constructor(
+				NotificationSelectResponse.class,
+				notification.id,
+				notification.actorId,
+				notification.actorName,
+				notification.actionType,
+				notification.targetType,
+				notification.targetId,
+				notification.notificationContent,
+				notification.projectId,
+				notification.projectStepId,
+				notification.actionDate
+			))
+			.from(notification)
+			.where(
+				notification.receiverMemberId.eq(memberId),
+				eqRead(isRead)
+			)
+			.orderBy(notification.actionDate.desc())
+			.offset(offset)
+			.limit(postPageSize)
+			.fetch();
+	}
+
+	private BooleanExpression eqRead(Boolean isRead) {
+		if (isRead == null) {
+			return null;
+		}
+
+		return notification.isRead.eq(isRead);
+	}
+}

--- a/src/main/java/kr/mywork/interfaces/notification/controller/NotificationController.java
+++ b/src/main/java/kr/mywork/interfaces/notification/controller/NotificationController.java
@@ -1,0 +1,63 @@
+package kr.mywork.interfaces.notification.controller;
+
+import java.util.List;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.Min;
+import kr.mywork.common.api.support.response.ApiResponse;
+import kr.mywork.common.auth.components.annotation.LoginMember;
+import kr.mywork.common.auth.components.dto.LoginMemberDetail;
+import kr.mywork.domain.notification.service.NotificationService;
+import kr.mywork.domain.notification.service.dto.response.NotificationReadResponse;
+import kr.mywork.domain.notification.service.dto.response.NotificationSelectResponse;
+import kr.mywork.domain.post.service.dto.response.PostApprovalResponse;
+import kr.mywork.domain.notification.service.dto.request.NotificationReadRequest;
+import kr.mywork.interfaces.notification.controller.dto.request.NotificationReadWebRequest;
+import kr.mywork.interfaces.notification.controller.dto.response.NotificationListSelectWebResponse;
+import kr.mywork.interfaces.notification.controller.dto.response.NotificationReadWebResponse;
+import kr.mywork.interfaces.notification.controller.dto.response.NotificationSelectWebResponse;
+import kr.mywork.interfaces.post.controller.dto.response.PostApprovalWebResponse;
+import lombok.AllArgsConstructor;
+
+@AllArgsConstructor
+@RestController
+@RequestMapping("/api/notifications")
+public class NotificationController {
+
+	private final NotificationService notificationService;
+
+	@GetMapping()
+	public ApiResponse<NotificationListSelectWebResponse> getNotification(
+		@LoginMember LoginMemberDetail loginMemberDetail,
+		@RequestParam(name = "page") @Min(value = 1, message = "{invalid.page-size}") final int page,
+		@RequestParam(name = "isRead", required = false) final Boolean isRead
+	) {
+		final List<NotificationSelectResponse> notificationSelectResponses = notificationService.findByConditionWithPaging(page,
+			isRead, loginMemberDetail.memberId());
+
+		final List<NotificationSelectWebResponse> notificationSelectWebResponses = notificationSelectResponses.stream()
+			.map(NotificationSelectWebResponse::from)
+			.toList();
+
+		return ApiResponse.success(new NotificationListSelectWebResponse(notificationSelectWebResponses));
+	}
+
+	@PutMapping("")
+	public ApiResponse<NotificationReadWebResponse> readNotification(
+		@RequestBody @Valid NotificationReadWebRequest notificationReadWebRequest,
+		@LoginMember LoginMemberDetail loginMemberDetail) {
+		NotificationReadRequest notificationReadRequest = notificationReadWebRequest.toServiceDto();
+
+		NotificationReadResponse notificationReadResponse = notificationService.readNotification(notificationReadRequest);
+
+		return ApiResponse.success(new NotificationReadWebResponse(notificationReadResponse.getId()));
+	}
+
+}

--- a/src/main/java/kr/mywork/interfaces/notification/controller/dto/request/NotificationReadWebRequest.java
+++ b/src/main/java/kr/mywork/interfaces/notification/controller/dto/request/NotificationReadWebRequest.java
@@ -1,0 +1,17 @@
+package kr.mywork.interfaces.notification.controller.dto.request;
+
+import java.util.UUID;
+
+import kr.mywork.domain.notification.service.dto.request.NotificationReadRequest;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class NotificationReadWebRequest {
+	private final UUID id;
+
+	public NotificationReadRequest toServiceDto() {
+		return new NotificationReadRequest(this.id);
+	}
+}

--- a/src/main/java/kr/mywork/interfaces/notification/controller/dto/response/NotificationListSelectWebResponse.java
+++ b/src/main/java/kr/mywork/interfaces/notification/controller/dto/response/NotificationListSelectWebResponse.java
@@ -1,0 +1,13 @@
+package kr.mywork.interfaces.notification.controller.dto.response;
+
+import java.util.List;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor
+@Getter
+public class NotificationListSelectWebResponse {
+
+	List<NotificationSelectWebResponse> notificationSelectWebResponses;
+}

--- a/src/main/java/kr/mywork/interfaces/notification/controller/dto/response/NotificationListWebResponse.java
+++ b/src/main/java/kr/mywork/interfaces/notification/controller/dto/response/NotificationListWebResponse.java
@@ -1,0 +1,11 @@
+package kr.mywork.interfaces.notification.controller.dto.response;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+
+public record NotificationListWebResponse (UUID actorId, String actorName, String actionType,
+										   String targetType, UUID targetId, String content, UUID projectId, UUID projectStepId,
+										   @JsonFormat(pattern = "yyyy-MM-dd HH:mm") LocalDateTime actionTime) {
+}

--- a/src/main/java/kr/mywork/interfaces/notification/controller/dto/response/NotificationReadWebResponse.java
+++ b/src/main/java/kr/mywork/interfaces/notification/controller/dto/response/NotificationReadWebResponse.java
@@ -1,0 +1,17 @@
+package kr.mywork.interfaces.notification.controller.dto.response;
+
+import java.util.UUID;
+
+import kr.mywork.domain.notification.service.dto.response.NotificationReadResponse;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class NotificationReadWebResponse {
+	private UUID id;
+
+	public NotificationReadResponse toServiceDto() {
+		return new NotificationReadResponse(this.id);
+	}
+}

--- a/src/main/java/kr/mywork/interfaces/notification/controller/dto/response/NotificationSelectWebResponse.java
+++ b/src/main/java/kr/mywork/interfaces/notification/controller/dto/response/NotificationSelectWebResponse.java
@@ -1,0 +1,28 @@
+package kr.mywork.interfaces.notification.controller.dto.response;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+
+import kr.mywork.domain.notification.service.dto.response.NotificationSelectResponse;
+
+public record NotificationSelectWebResponse (UUID id, UUID actorId, String actorName, String actionType,
+											 String targetType, UUID targetId, String content, UUID projectId, UUID projectStepId,
+											 @JsonFormat(pattern = "yyyy-MM-dd HH:mm") LocalDateTime actionTime) {
+
+	public static NotificationSelectWebResponse from(NotificationSelectResponse response) {
+		return new NotificationSelectWebResponse(
+			response.getId(),
+			response.getActorId(),
+			response.getActorName(),
+			response.getActionType(),
+			response.getTargetType(),
+			response.getTargetId(),
+			response.getContent(),
+			response.getProjectId(),
+			response.getProjectStepId(),
+			response.getActionTime()
+		);
+	}
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -55,6 +55,9 @@ dashboard:
 activityLog:
   page:
     size: 10
+notification:
+  page:
+    size: 10
 jwt:
   access-token:
     private-key: 126cab8a5d9087a27be4e2a0599682e2bab38e80201d1befa2dd9d55ecbdeac58bab0c84301ad9f9f8a71836825e5a7214e7a9fb17a8578418de6cfe9a15cbc7


### PR DESCRIPTION
## 📌 개요

- 게시글 상태 변경 시 알림 저장 기능을 구현했습니다.
- 이벤트 리스너 도입은 시간 제약으로 인해 이번 PR에서는 적용하지 않았습니다.
- 따라서 현재는 순차적(동기) 방식으로 알림을 저장합니다.


## 🛠️ 변경 사항

- 게시글 상태 변경에 대한 알림 저장 기능 추가
- Notification 도메인 및 저장 로직 구성
- NotificationSelectResponse 및 WebResponse 추가
- 알림 조회 API 기본 구현 (페이징, 읽음 여부 필터링 포함)

## ✅ 주요 체크 포인트

- [ ] 알림 저장 방식이 동기적으로 처리되었는데, 후속 리팩토링에서 이벤트 리스너로 분리해야함
- [ ] Notification 저장 및 조회 도메인/쿼리 구조가 확장 가능하게 설계되었는지
- [ ] 테스트코드/문서화 없습니다. 추후 바로 작성예정

## 🔁 테스트 결과

## 🔗 연관된 이슈
- #260 
