### PR TITLE
[feat] 회사 이미지 메타데이터 저장 로직 추가 (#273)

### DIFF
--- a/src/main/java/kr/mywork/domain/company/model/Company.java
+++ b/src/main/java/kr/mywork/domain/company/model/Company.java
@@ -11,6 +11,7 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.Enumerated;
 import jakarta.persistence.Id;
 import kr.mywork.domain.company.errors.CompanyErrorType;
+import kr.mywork.domain.company.errors.CompanyImageAlreadyExistException;
 import kr.mywork.domain.company.errors.CompanyImageEmptyException;
 import kr.mywork.domain.company.service.dto.request.CompanyUpdateRequest;
 import lombok.AccessLevel;
@@ -106,10 +107,6 @@ public class Company {
 		return String.format("/%s/%s", id, fileName);
 	}
 
-	public boolean existsImage() {
-		return !(this.fileName == null || this.fileName.isEmpty());
-	}
-
 	public boolean deleteImage() {
 		if (this.fileName == null) {
 			throw new CompanyImageEmptyException(CompanyErrorType.COMPANY_IMAGE_EMPTY);
@@ -117,5 +114,14 @@ public class Company {
 
 		this.fileName = null;
 		return true;
+	}
+
+	public boolean assignLogoImage(final String fileName) {
+		if (this.fileName == null || this.fileName.isEmpty()) {
+			this.fileName = fileName;
+			return true;
+		}
+
+		throw new CompanyImageAlreadyExistException(CompanyErrorType.COMPANY_IMAGE_EXIST);
 	}
 }

--- a/src/main/java/kr/mywork/domain/company/service/CompanyImageService.java
+++ b/src/main/java/kr/mywork/domain/company/service/CompanyImageService.java
@@ -10,7 +10,6 @@ import org.springframework.transaction.annotation.Transactional;
 
 import kr.mywork.domain.company.errors.CompanyErrorType;
 import kr.mywork.domain.company.errors.CompanyIdNotFoundException;
-import kr.mywork.domain.company.errors.CompanyImageAlreadyExistException;
 import kr.mywork.domain.company.errors.CompanyNotFoundException;
 import kr.mywork.domain.company.model.Company;
 import kr.mywork.domain.company.model.CompanyId;
@@ -38,13 +37,14 @@ public class CompanyImageService {
 			.orElseGet(() -> uploadNewCompanyImage(companyId, fileName));
 	}
 
+
 	private CompanyImageUploadUrlIssueResponse uploadCompanyImage(final String fileName, final Company company) {
-		if (company.existsImage()) {
-			throw new CompanyImageAlreadyExistException(CompanyErrorType.COMPANY_IMAGE_EXIST);
-		}
+		// S3 는 트랜잭션을 보장할 수 없으므로 DB 데이터를 선반영 + 삭제가 되어야 이미지 업로드 가능
+		company.assignLogoImage(fileName);
 
 		final URL uploadUrl = companyImageFileHandler.createUploadUrl(company.getId(), fileName);
-			return new CompanyImageUploadUrlIssueResponse(company.getId(), uploadUrl.toString());
+
+		return new CompanyImageUploadUrlIssueResponse(company.getId(), uploadUrl.toString());
 	}
 
 	private CompanyImageUploadUrlIssueResponse uploadNewCompanyImage(final UUID companyId, final String fileName) {


### PR DESCRIPTION
## 📌 개요

- 회사 이미지 메타데이터 저장 로직 추가

## 🛠️ 변경 사항

- 회사 이미지 메타데이터 저장 로직 추가
   - 이미지가 없을 경우에만 업로드 가능

## ✅ 주요 체크 포인트

- [ ] 저장 후 이미지가 정상적으로 저장되는지 확인

## 🔁 테스트 결과

- 현재 단계 테스트 검증 완료

## 🔗 연관된 이슈

- #273 

<br>

## 📑 레퍼런스

- 없음