### PR TITLE
[feat] 프로젝트 메니저가 상태값 수정 api

### DIFF
--- a/src/main/java/kr/mywork/common/api/components/interceptor/PermissionCheckInterceptor.java
+++ b/src/main/java/kr/mywork/common/api/components/interceptor/PermissionCheckInterceptor.java
@@ -1,0 +1,75 @@
+package kr.mywork.common.api.components.interceptor;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import kr.mywork.domain.auth.dto.MemberDetails;
+import kr.mywork.domain.member.model.MemberRole;
+import kr.mywork.domain.project.model.ProjectMember;
+import kr.mywork.domain.project_member.repository.ProjectMemberRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.servlet.HandlerInterceptor;
+
+import java.io.IOException;
+import java.util.Optional;
+import java.util.UUID;
+
+@Slf4j
+@RequiredArgsConstructor
+public class PermissionCheckInterceptor implements HandlerInterceptor {
+
+    private final ProjectMemberRepository projectMemberRepository;
+
+    @Override
+    public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) throws IOException {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+
+        if (authentication == null || !authentication.isAuthenticated()) {
+            return sendJsonError(response, HttpServletResponse.SC_UNAUTHORIZED, "인증 정보가 없습니다.");
+        }
+
+        if (!(authentication.getPrincipal() instanceof MemberDetails memberDetails)) {
+            return sendJsonError(response, HttpServletResponse.SC_UNAUTHORIZED, "인증된 사용자가 아닙니다.");
+        }
+
+        String memberRole = memberDetails.getAuthorityAsStr();
+        UUID memberId = memberDetails.getId();
+        UUID projectId = UUID.fromString(request.getParameter("projectId"));
+
+        if(MemberRole.SYSTEM_ADMIN.isSameRoleName(memberRole)){
+            return true;
+        }
+
+        if (!request.getMethod().equalsIgnoreCase("GET")) {
+            Optional<ProjectMember> projectManager = projectMemberRepository.findProjectManagerByMemberIdAndProjectId(memberId, projectId);
+            if (projectManager.isEmpty()) {
+                return sendJsonError(response, HttpServletResponse.SC_FORBIDDEN, "해당 프로젝트에 대한 접근 권한이 없습니다.");
+            }
+        }
+
+        return true;
+    }
+
+
+
+
+    private boolean sendJsonError(HttpServletResponse response, int status, String message) throws IOException {
+        response.setStatus(status);
+        response.setContentType("application/json;charset=UTF-8");
+        response.getWriter().write(String.format("""
+            {
+              "result": "ERROR",
+              "data": null,
+              "error": {
+                "code": "INTERCEPTOR_%d",
+                "message": "%s",
+                "data": null
+              }
+            }
+            """, status, message));
+        response.flushBuffer();
+        return false;
+    }
+}

--- a/src/main/java/kr/mywork/common/api/config/WebConfig.java
+++ b/src/main/java/kr/mywork/common/api/config/WebConfig.java
@@ -1,13 +1,24 @@
 package kr.mywork.common.api.config;
 
+import kr.mywork.common.api.components.interceptor.PermissionCheckInterceptor;
+import kr.mywork.domain.project_member.repository.ProjectMemberRepository;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.ResourceHandlerRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 @Configuration
 public class WebConfig implements WebMvcConfigurer {
+	private final ProjectMemberRepository projectMemberRepository;
+
+	@Autowired
+	public WebConfig(ProjectMemberRepository projectMemberRepository) {
+		this.projectMemberRepository = projectMemberRepository;
+	}
+
 	@Override
 	public void addResourceHandlers(final ResourceHandlerRegistry registry) {
 		registry.addResourceHandler("/static/**").addResourceLocations("classpath:/static/");
@@ -26,5 +37,11 @@ public class WebConfig implements WebMvcConfigurer {
 					.allowCredentials(true); // 인증 정보 포함 허용
 			}
 		};
+	}
+
+	@Override
+	public void addInterceptors(InterceptorRegistry registry) {
+		registry.addInterceptor(new PermissionCheckInterceptor(projectMemberRepository))
+				.addPathPatterns("/api/projects/project-status"); // 권한 체크할 API 경로
 	}
 }

--- a/src/main/java/kr/mywork/common/auth/config/SecurityConfig.java
+++ b/src/main/java/kr/mywork/common/auth/config/SecurityConfig.java
@@ -1,7 +1,18 @@
 package kr.mywork.common.auth.config;
 
-import java.util.List;
-
+import com.fasterxml.jackson.databind.ObjectMapper;
+import kr.mywork.common.api.components.filter.HttpLoggingFilter;
+import kr.mywork.common.api.components.filter.RequestTrackingIdFilter;
+import kr.mywork.domain.auth.service.JwtTokenProvider;
+import kr.mywork.domain.auth.service.TokenAuthenticationService;
+import kr.mywork.domain.member.model.MemberRole;
+import kr.mywork.interfaces.auth.filter.JwtAuthenticationFilter;
+import kr.mywork.interfaces.auth.filter.JwtLoginFilter;
+import kr.mywork.interfaces.auth.handler.error.JwtAccessDeniedHandler;
+import kr.mywork.interfaces.auth.handler.error.JwtAuthenticationEntryPoint;
+import kr.mywork.interfaces.auth.handler.error.LoginFailureHandler;
+import kr.mywork.interfaces.auth.handler.success.LoginSuccessHandler;
+import lombok.RequiredArgsConstructor;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -20,20 +31,7 @@ import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-
-import kr.mywork.common.api.components.filter.HttpLoggingFilter;
-import kr.mywork.common.api.components.filter.RequestTrackingIdFilter;
-import kr.mywork.domain.auth.service.JwtTokenProvider;
-import kr.mywork.domain.auth.service.TokenAuthenticationService;
-import kr.mywork.domain.member.model.MemberRole;
-import kr.mywork.interfaces.auth.filter.JwtAuthenticationFilter;
-import kr.mywork.interfaces.auth.filter.JwtLoginFilter;
-import kr.mywork.interfaces.auth.handler.error.JwtAccessDeniedHandler;
-import kr.mywork.interfaces.auth.handler.error.JwtAuthenticationEntryPoint;
-import kr.mywork.interfaces.auth.handler.error.LoginFailureHandler;
-import kr.mywork.interfaces.auth.handler.success.LoginSuccessHandler;
-import lombok.RequiredArgsConstructor;
+import java.util.List;
 
 @Configuration
 @RequiredArgsConstructor
@@ -82,7 +80,11 @@ public class SecurityConfig {
 						MemberRole.SYSTEM_ADMIN.name(),
 						MemberRole.DEV_ADMIN.name(),
 						MemberRole.CLIENT_ADMIN.name())
-					.requestMatchers(HttpMethod.GET, "/api/company/**")
+					.requestMatchers(HttpMethod.PUT, "/api/project-member/manager").hasAnyRole(
+							MemberRole.SYSTEM_ADMIN.name(),
+							MemberRole.DEV_ADMIN.name(),
+							MemberRole.CLIENT_ADMIN.name())
+						.requestMatchers(HttpMethod.GET, "/api/company/**")
 					.hasAnyRole(
 						MemberRole.SYSTEM_ADMIN.name(),
 						MemberRole.DEV_ADMIN.name(),

--- a/src/main/java/kr/mywork/domain/project/model/Project.java
+++ b/src/main/java/kr/mywork/domain/project/model/Project.java
@@ -88,5 +88,6 @@ public class Project {
 		this.step = request.step();
 		this.detail = request.detail();
 		this.deleted = request.deleted();
+		this.projectAmount = request.projectAmount();
 	}
 }

--- a/src/main/java/kr/mywork/domain/project/model/Project.java
+++ b/src/main/java/kr/mywork/domain/project/model/Project.java
@@ -90,4 +90,7 @@ public class Project {
 		this.deleted = request.deleted();
 		this.projectAmount = request.projectAmount();
 	}
+	public void updateStatus(String status){
+		this.step = status;
+	}
 }

--- a/src/main/java/kr/mywork/domain/project/model/ProjectMember.java
+++ b/src/main/java/kr/mywork/domain/project/model/ProjectMember.java
@@ -1,19 +1,17 @@
 package kr.mywork.domain.project.model;
 
-import java.time.LocalDateTime;
-import java.util.UUID;
-
-import org.hibernate.annotations.CreationTimestamp;
-import org.hibernate.annotations.UpdateTimestamp;
-
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
-
 import kr.mywork.common.rdb.id.UnixTimeOrderedUuidGeneratedValue;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
 
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -60,5 +58,9 @@ public class ProjectMember {
 
 	public void restore() {
 		this.deleted = false;
+	}
+
+	public void changeManager(Boolean isManager){
+        this.manager = !isManager;
 	}
 }

--- a/src/main/java/kr/mywork/domain/project/service/ProjectService.java
+++ b/src/main/java/kr/mywork/domain/project/service/ProjectService.java
@@ -601,4 +601,21 @@ public class ProjectService {
 
 		return new DashboardCountSummaryResponse(totalCount, inProgressCount, completedCount);
 	}
+	@Transactional
+	public String getProjectStatus(UUID projectId){
+		final Project project = projectRepository.findById(projectId)
+				.orElseThrow(() -> new ProjectNotFoundException(ProjectErrorType.PROJECT_NOT_FOUND));
+
+		return project.getStep();
+	}
+
+	@Transactional
+	public UUID updateProjectStatus(UUID projectId, String status){
+		final Project project = projectRepository.findById(projectId)
+				.orElseThrow(() -> new ProjectNotFoundException(ProjectErrorType.PROJECT_NOT_FOUND));
+
+		project.updateStatus(status);
+
+		return project.getId();
+	}
 }

--- a/src/main/java/kr/mywork/domain/project_member/repository/ProjectMemberRepository.java
+++ b/src/main/java/kr/mywork/domain/project_member/repository/ProjectMemberRepository.java
@@ -15,4 +15,5 @@ public interface ProjectMemberRepository {
 	List<ProjectMember> findAllByMemberId(UUID memberId);
 	List<UUID> findProjectIdsByMemberId(UUID memberId);
 	List<ProjectMember> getUserProjectIds(UUID memberId);
+	Optional<ProjectMember>findProjectManagerByMemberIdAndProjectId(UUID memberId ,UUID projectId);
 }

--- a/src/main/java/kr/mywork/domain/project_member/service/ProjectMemberService.java
+++ b/src/main/java/kr/mywork/domain/project_member/service/ProjectMemberService.java
@@ -8,6 +8,7 @@ import kr.mywork.domain.project.model.ProjectMember;
 import kr.mywork.domain.project_member.error.ProjectMemberErrorType;
 import kr.mywork.domain.project_member.error.ProjectMemberNotFoundException;
 import kr.mywork.domain.project_member.repository.ProjectMemberRepository;
+import kr.mywork.domain.project_member.service.dto.request.ProjectManagerUpdateRequest;
 import kr.mywork.domain.project_member.service.dto.response.CompanyMemberInProjectResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.ApplicationEventPublisher;
@@ -72,4 +73,19 @@ public class ProjectMemberService {
 
 		return projectMember.getId();
 	}
+	@Transactional
+	public UUID updateProjectManager(ProjectManagerUpdateRequest projectManagerUpdateRequest){
+		UUID memberId = projectManagerUpdateRequest.memberId();
+		UUID projectId = projectManagerUpdateRequest.projectId();
+
+		ProjectMember projectMember = projectMemberRepository.findByMemberIdAndProjectId(memberId, projectId)
+				.orElseThrow(() -> new ProjectMemberNotFoundException(ProjectMemberErrorType.PROJECT_MEMBER_NOT_FOUND));
+
+		//true -> false , false -> true
+		projectMember.changeManager(projectMember.getManager());
+
+
+		return projectMember.getMemberId();
+	}
+
 }

--- a/src/main/java/kr/mywork/domain/project_member/service/dto/request/ProjectManagerUpdateRequest.java
+++ b/src/main/java/kr/mywork/domain/project_member/service/dto/request/ProjectManagerUpdateRequest.java
@@ -1,0 +1,6 @@
+package kr.mywork.domain.project_member.service.dto.request;
+
+import java.util.UUID;
+
+public record ProjectManagerUpdateRequest(UUID memberId , UUID projectId) {
+}

--- a/src/main/java/kr/mywork/infrastructure/project_member/rdb/QueryDslProjectMemberRepository.java
+++ b/src/main/java/kr/mywork/infrastructure/project_member/rdb/QueryDslProjectMemberRepository.java
@@ -76,6 +76,18 @@ public class QueryDslProjectMemberRepository implements ProjectMemberRepository 
 	}
 
 	@Override
+	public Optional<ProjectMember> findProjectManagerByMemberIdAndProjectId(UUID memberId, UUID projectId) {
+		return Optional.ofNullable
+				(queryFactory
+				.selectFrom(projectMember)
+				.where(
+					projectMember.memberId.eq(memberId)
+						.and(projectMember.projectId.eq(projectId))
+							.and(projectMember.manager.isTrue())
+				).fetchOne());
+	}
+
+	@Override
 	public List<ProjectMember> findAllByMemberId(UUID memberId) {
 		return queryFactory
 			.selectFrom(projectMember)

--- a/src/main/java/kr/mywork/interfaces/project/controller/ProjectController.java
+++ b/src/main/java/kr/mywork/interfaces/project/controller/ProjectController.java
@@ -15,6 +15,8 @@ import kr.mywork.interfaces.project.controller.dto.request.ProjectDeleteWebReque
 import kr.mywork.interfaces.project.controller.dto.request.ProjectUpdateWebRequest;
 import kr.mywork.interfaces.project.controller.dto.response.*;
 import kr.mywork.interfaces.project.dto.response.ProjectMemberListWebResponse;
+import kr.mywork.interfaces.project_step.dto.response.ProjectStatusUpdateWebResponse;
+import kr.mywork.interfaces.project_step.dto.response.ProjectStatusWebResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
@@ -131,5 +133,30 @@ public class ProjectController {
 				.toList();
 
 		return ApiResponse.success(new MyProjectListWebResponse(webList));
+	}
+
+	@GetMapping("/project-status")
+	public ApiResponse<ProjectStatusWebResponse> getProjectStatus(
+			@RequestParam UUID projectId
+	){
+		final String projectStatus = projectService.getProjectStatus(projectId);
+
+		final ProjectStatusWebResponse projectStatusWebResponse = new ProjectStatusWebResponse(projectStatus);
+
+		return ApiResponse.success(projectStatusWebResponse);
+	}
+
+	@PostMapping("/project-status")
+	public ApiResponse<ProjectStatusUpdateWebResponse> updateProjectStatus(
+			@RequestParam UUID projectId,
+			@RequestParam(name = "status", required = false)
+			@Pattern(regexp = PROJECT_STEP_TYPE, message = "{project.invalid-status}") final String status
+	){
+		final UUID updatedProjectId = projectService.updateProjectStatus(projectId,status);
+
+		final ProjectStatusUpdateWebResponse projectStatusUpdateWebResponse =  new ProjectStatusUpdateWebResponse(updatedProjectId);
+
+		return ApiResponse.success(projectStatusUpdateWebResponse);
+
 	}
 }

--- a/src/main/java/kr/mywork/interfaces/project_member/controller/ProjectMemberController.java
+++ b/src/main/java/kr/mywork/interfaces/project_member/controller/ProjectMemberController.java
@@ -4,8 +4,11 @@ import kr.mywork.common.api.support.response.ApiResponse;
 import kr.mywork.common.auth.components.annotation.LoginMember;
 import kr.mywork.common.auth.components.dto.LoginMemberDetail;
 import kr.mywork.domain.project_member.service.ProjectMemberService;
+import kr.mywork.domain.project_member.service.dto.request.ProjectManagerUpdateRequest;
 import kr.mywork.domain.project_member.service.dto.response.CompanyMemberInProjectResponse;
+import kr.mywork.interfaces.project_member.controller.dto.request.ProjectManagerUpdateWebRequest;
 import kr.mywork.interfaces.project_member.controller.dto.response.CompanyMembersInProjectWebResponse;
+import kr.mywork.interfaces.project_member.controller.dto.response.ProjectManagerUpdateWebResponse;
 import kr.mywork.interfaces.project_member.controller.dto.response.ProjectMemberAddWebResponse;
 import kr.mywork.interfaces.project_member.controller.dto.response.ProjectMemberDeleteWebResponse;
 import lombok.RequiredArgsConstructor;
@@ -55,6 +58,19 @@ public class ProjectMemberController {
 		final ProjectMemberDeleteWebResponse projectMemberDeleteWebResponse = new ProjectMemberDeleteWebResponse(deletedMemberId);
 
 		return ApiResponse.success(projectMemberDeleteWebResponse);
+	}
+
+	@PutMapping("/manager")
+	public ApiResponse<ProjectManagerUpdateWebResponse> projectManagerUpdateWebResponseApiResponse(
+			@RequestBody ProjectManagerUpdateWebRequest projectManagerUpdateWebRequest
+	){
+		final ProjectManagerUpdateRequest projectManagerUpdateRequest = projectManagerUpdateWebRequest.toServiceDto();
+
+		final UUID updatedManagerId = projectMemberService.updateProjectManager(projectManagerUpdateRequest);
+
+		final ProjectManagerUpdateWebResponse projectManagerUpdateWebResponse = new ProjectManagerUpdateWebResponse(updatedManagerId);
+
+		return ApiResponse.success(projectManagerUpdateWebResponse);
 	}
 }
 

--- a/src/main/java/kr/mywork/interfaces/project_member/controller/dto/request/ProjectManagerUpdateWebRequest.java
+++ b/src/main/java/kr/mywork/interfaces/project_member/controller/dto/request/ProjectManagerUpdateWebRequest.java
@@ -1,0 +1,16 @@
+package kr.mywork.interfaces.project_member.controller.dto.request;
+
+import kr.mywork.domain.project_member.service.dto.request.ProjectManagerUpdateRequest;
+
+import java.util.UUID;
+
+public record ProjectManagerUpdateWebRequest(UUID memberId , UUID projectId) {
+
+    public  ProjectManagerUpdateRequest toServiceDto(){
+        return new ProjectManagerUpdateRequest(
+                this.memberId,
+                this.projectId
+        );
+
+    }
+}

--- a/src/main/java/kr/mywork/interfaces/project_member/controller/dto/response/ProjectManagerUpdateWebResponse.java
+++ b/src/main/java/kr/mywork/interfaces/project_member/controller/dto/response/ProjectManagerUpdateWebResponse.java
@@ -1,0 +1,6 @@
+package kr.mywork.interfaces.project_member.controller.dto.response;
+
+import java.util.UUID;
+
+public record ProjectManagerUpdateWebResponse(UUID memberId) {
+}

--- a/src/main/java/kr/mywork/interfaces/project_step/dto/response/ProjectStatusUpdateWebResponse.java
+++ b/src/main/java/kr/mywork/interfaces/project_step/dto/response/ProjectStatusUpdateWebResponse.java
@@ -1,0 +1,6 @@
+package kr.mywork.interfaces.project_step.dto.response;
+
+import java.util.UUID;
+
+public record ProjectStatusUpdateWebResponse(UUID projectId) {
+}

--- a/src/main/java/kr/mywork/interfaces/project_step/dto/response/ProjectStatusWebResponse.java
+++ b/src/main/java/kr/mywork/interfaces/project_step/dto/response/ProjectStatusWebResponse.java
@@ -1,0 +1,4 @@
+package kr.mywork.interfaces.project_step.dto.response;
+
+public record ProjectStatusWebResponse(String projectStatus) {
+}

--- a/src/test/java/kr/mywork/docs/ProjectDocumentationTest.java
+++ b/src/test/java/kr/mywork/docs/ProjectDocumentationTest.java
@@ -388,4 +388,120 @@ public class ProjectDocumentationTest extends RestDocsDocumentation {
 								fieldWithPath("error").type(JsonFieldType.NULL).description("에러 정보"))
 						.build());
 	}
+	@Test
+	@DisplayName("프로젝트 status 조회")
+	@Sql("classpath:sql/project-status.sql")
+	void 프로젝트_상태값_조회_성공() throws Exception {
+		//given
+		final String accessToken = createDevAdminAccessToken();
+		UUID projectId = UUID.fromString("01973a42-0995-74aa-9298-a25cb8dae6ef");
+
+		//when
+		final ResultActions result = mockMvc.perform(
+				get("/api/projects/project-status?projectId={projectId}",projectId)
+						.contentType(MediaType.APPLICATION_JSON)
+						.header(HttpHeaders.AUTHORIZATION, toBearerAuthorizationHeader(accessToken)));
+
+		//then
+		result.andExpectAll(
+						status().isOk(),
+						jsonPath("$.result").value(ResultType.SUCCESS.name()),
+						jsonPath("$.data").exists(),
+						jsonPath("$.error").doesNotExist())
+				.andDo(document("project-status-success", projectStatusSuccessResource()));
+	}
+
+	private ResourceSnippet projectStatusSuccessResource() {
+		return resource(
+				ResourceSnippetParameters.builder()
+						.tag("Project API")
+						.summary("프로젝트 상태값 조회 API")
+						.description("프로젝트 상태값을 조회한다")
+						.requestHeaders(
+								headerWithName(HttpHeaders.CONTENT_TYPE).description("컨텐츠 타입"),
+								headerWithName(HttpHeaders.AUTHORIZATION).description("엑세스 토큰"))
+						.responseFields(
+								fieldWithPath("result").type(JsonFieldType.STRING).description("응답 결과"),
+								fieldWithPath("data.projectStatus").type(JsonFieldType.STRING).description("프로젝트 상태값"),
+								fieldWithPath("error").type(JsonFieldType.NULL).description("에러 정보"))
+						.build());
+	}
+	@Test
+	@DisplayName("프로젝트 status 업데이트")
+	@Sql("classpath:sql/project-status.sql")
+	void 프로젝트_상태값_업데이트_성공() throws Exception {
+		//given
+		final String accessToken = createSystemAccessToken();
+		UUID projectId = UUID.fromString("01973a42-0995-74aa-9298-a25cb8dae6ef");
+
+		//when
+		final ResultActions result = mockMvc.perform(
+				post("/api/projects/project-status?projectId={projectId}&status={status}",projectId,"COMPLETED")
+						.contentType(MediaType.APPLICATION_JSON)
+						.header(HttpHeaders.AUTHORIZATION, toBearerAuthorizationHeader(accessToken)));
+
+		//then
+		result.andExpectAll(
+						status().isOk(),
+						jsonPath("$.result").value(ResultType.SUCCESS.name()),
+						jsonPath("$.data").exists(),
+						jsonPath("$.error").doesNotExist())
+				.andDo(document("project-status-updated-success", projectStatusUpdateSuccessResource()));
+	}
+
+	private ResourceSnippet projectStatusUpdateSuccessResource() {
+		return resource(
+				ResourceSnippetParameters.builder()
+						.tag("Project API")
+						.summary("프로젝트 상태값 업데이트 API")
+						.description("프로젝트 상태값을 업데이트 한다")
+						.requestHeaders(
+								headerWithName(HttpHeaders.CONTENT_TYPE).description("컨텐츠 타입"),
+								headerWithName(HttpHeaders.AUTHORIZATION).description("엑세스 토큰"))
+						.responseFields(
+								fieldWithPath("result").type(JsonFieldType.STRING).description("응답 결과"),
+								fieldWithPath("data.projectId").type(JsonFieldType.STRING).description("변경된 프로젝트 id"),
+								fieldWithPath("error").type(JsonFieldType.NULL).description("에러 정보"))
+						.build());
+	}
+	@Test
+	@DisplayName("프로젝트 status 업데이트 실패")
+	@Sql("classpath:sql/project-status.sql")
+	void 프로젝트_상태값_업데이트_실패() throws Exception {
+		//given
+		final String accessToken = createDevAdminAccessToken();
+		UUID projectId = UUID.fromString("01973a42-0995-74aa-9298-a25cb8dae6ef");
+
+		//when
+		final ResultActions result = mockMvc.perform(
+				post("/api/projects/project-status?projectId={projectId}&status={status}",projectId,"COMPLETED")
+						.contentType(MediaType.APPLICATION_JSON)
+						.header(HttpHeaders.AUTHORIZATION, toBearerAuthorizationHeader(accessToken)));
+
+		//then
+		result.andExpectAll(
+						status().is4xxClientError(),
+						jsonPath("$.result").value(ResultType.ERROR.name()),
+						jsonPath("$.data").doesNotExist(),
+						jsonPath("$.error").exists())
+				.andDo(document("project-status-updated-fail", projectStatusUpdateFailResource()));
+	}
+
+	private ResourceSnippet projectStatusUpdateFailResource() {
+		return resource(
+				ResourceSnippetParameters.builder()
+						.tag("Project API")
+						.summary("프로젝트 상태값 업데이트 API")
+						.description("프로젝트 상태값을 업데이트 한다")
+						.requestHeaders(
+								headerWithName(HttpHeaders.CONTENT_TYPE).description("컨텐츠 타입"),
+								headerWithName(HttpHeaders.AUTHORIZATION).description("엑세스 토큰"))
+						.responseFields(
+								fieldWithPath("result").type(JsonFieldType.STRING).description("응답 결과"),
+								fieldWithPath("data").type(JsonFieldType.NULL).description("응답 데이터"),
+								fieldWithPath("error.code").type(JsonFieldType.STRING).description("에러 코드"),
+								fieldWithPath("error.message").type(JsonFieldType.STRING).description("에러 정보"),
+								fieldWithPath("error.data").type(JsonFieldType.NULL).description("에러 정보"))
+						.build());
+	}
 }

--- a/src/test/java/kr/mywork/interfaces/post/controller/PostControllerTest.java
+++ b/src/test/java/kr/mywork/interfaces/post/controller/PostControllerTest.java
@@ -3,6 +3,7 @@ package kr.mywork.interfaces.post.controller;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import kr.mywork.common.api.support.response.ResultType;
 import kr.mywork.domain.project.service.ProjectService;
+import kr.mywork.domain.project_member.repository.ProjectMemberRepository;
 import kr.mywork.interfaces.project.controller.ProjectController;
 import kr.mywork.interfaces.project.controller.dto.request.ProjectCreateWebRequest;
 import org.junit.jupiter.api.DisplayName;
@@ -45,6 +46,9 @@ class PostControllerTest {
 
 	@MockitoBean
 	private ProjectService projectService;
+
+	@MockitoBean
+	private ProjectMemberRepository projectMemberRepository;
 
 	@Test
 	@DisplayName("프로젝트 생성 성공")

--- a/src/test/java/kr/mywork/interfaces/project_step/controller/ProjectStepControllerTest.java
+++ b/src/test/java/kr/mywork/interfaces/project_step/controller/ProjectStepControllerTest.java
@@ -3,6 +3,7 @@ package kr.mywork.interfaces.project_step.controller;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import kr.mywork.common.api.support.response.ResultType;
 import kr.mywork.domain.post.service.PostService;
+import kr.mywork.domain.project_member.repository.ProjectMemberRepository;
 import kr.mywork.domain.project_step.serivce.ProjectStepService;
 import kr.mywork.domain.project_step.serivce.dto.response.ProjectStepUpdateResponse;
 import kr.mywork.interfaces.project_step.dto.request.ProjectStepCreateWebRequest;
@@ -54,6 +55,9 @@ class ProjectStepControllerTest {
 
 	@MockitoBean
 	private PostService postService;
+
+	@MockitoBean
+	private ProjectMemberRepository projectMemberRepository;
 
 	@Test
 	@DisplayName("프로젝트 단계 목록 생성 성공")

--- a/src/test/resources/sql/project-status.sql
+++ b/src/test/resources/sql/project-status.sql
@@ -1,0 +1,11 @@
+INSERT INTO project (id, name, start_at, end_at, step, created_at, modified_at, detail, deleted,project_amount)
+VALUES (UNHEX(REPLACE('01973a42-0995-74aa-9298-a25cb8dae6ef', '-', '')),
+        '테스트 프로젝트',
+        NOW(),
+        NOW(),
+        'IN_PROGRESS',
+        NOW(),
+        NOW(),
+        '테스트용 프로젝트입니다',
+        0,
+        100);


### PR DESCRIPTION
## 📌 개요

- 프로젝트 메니저가 상태값 수정 api

## 🛠️ 변경 사항
-  프로젝트 상태값 조회 api
-프로젝트 상태값 변경 api
- 변경 가능한 사람인지 확인하는 인터셉터 작성.
- 프로젝트 수정시 프로젝트 금액 추가되도록 필드추가
- 프로젝트 메니저 할당 하는 api 추가

## ✅ 주요 체크 포인트

- [ ] 프로젝트 리더 할당
- [ ] 프로젝트 리더가 상태값 변경 
- [ ] 다른권한 프로젝트 상태값 변경 불가
- [ ] 시스템어드민 상태값 변경 가능
- [ ] 테스트 
## 🔁 테스트 결과

![image](https://github.com/user-attachments/assets/40c240f7-115a-49c7-b7a9-38ad7d860aed)

## 🔗 연관된 이슈
#276 
