### PR TITLE
localstack container CORS 환경변수 추가

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -25,6 +25,10 @@ services:
       - AWS_ACCESS_KEY_ID=test
       - AWS_SECRET_ACCESS_KEY=test
       - AWS_DEFAULT_REGION=us-east-1
+      # CORS 설정 추가
+      - EXTRA_CORS_ALLOWED_ORIGINS=http://localhost:3000
+      - EXTRA_CORS_ALLOWED_HEADERS=*
+      - EXTRA_CORS_ALLOWED_METHODS=GET,PUT,POST,DELETE,HEAD,OPTIONS
     volumes:
       - "./localstack:/tmp/localstack"
       - "/var/run/docker.sock:/var/run/docker.sock"


### PR DESCRIPTION
## 📌 개요
LocalStack CORS 설정을 통해 프론트엔드에서 S3 프리사인드 URL 파일 업로드 시 발생하는 CORS 에러를 해결했습니다.

## 🛠️ 변경 사항
- 도커 컴포즈파일에 CORS 환경변수 추가하였습니다.

## 문제상황
### CORS 이슈로 인한 업로드 실패 과정
<img width="1356" alt="스크린샷 2025-06-29 오후 10 15 42" src="https://github.com/user-attachments/assets/f85d3ac7-eb9e-4442-991c-f14a1384e69b" />

### CORS를 해결한 업로드 과정
<img width="1398" alt="스크린샷 2025-06-29 오후 10 17 35" src="https://github.com/user-attachments/assets/93096570-caa5-4cbc-ad5f-1a78d6935e6f" />


## ✅ 주요 체크 포인트
- [x] LocalStack 버전 호환성: 0.14.3 버전에서 EXTRA_CORS_ALLOWED_* 환경변수 형식 사용
- [x] 환경변수 우선순위: Generic Proxy 레벨 CORS 설정이 S3 서비스 레벨보다 우선 적용됨
- [x] 컨테이너 재시작 필요: 환경변수 변경 후 docker-compose down && docker-compose up -d 실행 필요

## 🔁 테스트 결과


## 🔗 연관된 이슈
- #281 
