### PR TITLE
[feat] 게시글 발급 아이디 일괄 삭제 스케줄러 추가

### DIFF
--- a/src/main/java/kr/mywork/common/schedules/ScheduleConfig.java
+++ b/src/main/java/kr/mywork/common/schedules/ScheduleConfig.java
@@ -1,0 +1,9 @@
+package kr.mywork.common.schedules;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableScheduling;
+
+@Configuration
+@EnableScheduling
+public class ScheduleConfig {
+}

--- a/src/main/java/kr/mywork/domain/post/model/PostId.java
+++ b/src/main/java/kr/mywork/domain/post/model/PostId.java
@@ -1,7 +1,12 @@
 package kr.mywork.domain.post.model;
 
+import java.time.LocalDateTime;
 import java.util.UUID;
 
+import org.hibernate.annotations.ColumnDefault;
+import org.hibernate.annotations.CreationTimestamp;
+
+import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
 import lombok.AccessLevel;
@@ -15,6 +20,11 @@ public class PostId {
 	@Id
 	@Getter
 	private UUID id;
+
+	@Column(nullable = false, columnDefinition = "timestamp")
+	@CreationTimestamp
+	@ColumnDefault("'1970-01-01 00:00:01'")
+	private LocalDateTime createdAt;
 
 	public PostId(final UUID id) {
 		this.id = id;

--- a/src/main/java/kr/mywork/domain/post/repository/PostIdRepository.java
+++ b/src/main/java/kr/mywork/domain/post/repository/PostIdRepository.java
@@ -1,5 +1,6 @@
 package kr.mywork.domain.post.repository;
 
+import java.time.LocalDateTime;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -9,4 +10,6 @@ public interface PostIdRepository {
 	UUID save(UUID postId);
 
 	Optional<PostId> findById(UUID id);
+
+	Long deleteIssuedPostIdsLessOrEqualLimitTime(LocalDateTime limitTime);
 }

--- a/src/main/java/kr/mywork/domain/post/service/PostIdService.java
+++ b/src/main/java/kr/mywork/domain/post/service/PostIdService.java
@@ -1,7 +1,9 @@
 package kr.mywork.domain.post.service;
 
+import java.time.LocalDateTime;
 import java.util.UUID;
 
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -14,11 +16,19 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class PostIdService {
 
+	@Value("${post.issued-id.created-limit-hour}")
+	private int createdLimitHour;
+
 	private final PostIdRepository postIdRepository;
 
 	@Transactional
 	public UUID createPostId() {
 		final UUID postId = Generators.timeBasedEpochGenerator().generate();
 		return postIdRepository.save(postId);
+	}
+
+	@Transactional
+	public Long deleteIssuedPostIds(final LocalDateTime nowDateTime) {
+		return postIdRepository.deleteIssuedPostIdsLessOrEqualLimitTime(nowDateTime.minusHours(createdLimitHour));
 	}
 }

--- a/src/main/java/kr/mywork/domain/post/service/PostIdService.java
+++ b/src/main/java/kr/mywork/domain/post/service/PostIdService.java
@@ -1,0 +1,24 @@
+package kr.mywork.domain.post.service;
+
+import java.util.UUID;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.fasterxml.uuid.Generators;
+
+import kr.mywork.domain.post.repository.PostIdRepository;
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class PostIdService {
+
+	private final PostIdRepository postIdRepository;
+
+	@Transactional
+	public UUID createPostId() {
+		final UUID postId = Generators.timeBasedEpochGenerator().generate();
+		return postIdRepository.save(postId);
+	}
+}

--- a/src/main/java/kr/mywork/domain/post/service/PostService.java
+++ b/src/main/java/kr/mywork/domain/post/service/PostService.java
@@ -10,8 +10,6 @@ import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import com.fasterxml.uuid.Generators;
-
 import kr.mywork.common.auth.components.dto.LoginMemberDetail;
 import kr.mywork.domain.activityLog.listener.eventObject.CreateEventObject;
 import kr.mywork.domain.activityLog.listener.eventObject.DeleteEventObject;
@@ -89,12 +87,6 @@ public class PostService {
 		eventPublisher.publishEvent(new ModifyEventObject(before, post, loginMemberDetail));
 
 		return new PostApprovalResponse(post.getId(), post.getApproval());
-	}
-
-	@Transactional
-	public UUID createPostId() {
-		final UUID postId = Generators.timeBasedEpochGenerator().generate();
-		return postIdRepository.save(postId);
 	}
 
 	@Transactional

--- a/src/main/java/kr/mywork/infrastructure/post/rdb/QueryDslPostIdRepository.java
+++ b/src/main/java/kr/mywork/infrastructure/post/rdb/QueryDslPostIdRepository.java
@@ -2,6 +2,7 @@ package kr.mywork.infrastructure.post.rdb;
 
 import static kr.mywork.domain.post.model.QPostId.*;
 
+import java.time.LocalDateTime;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -35,4 +36,10 @@ public class QueryDslPostIdRepository implements PostIdRepository {
 		return Optional.ofNullable(findPostId);
 	}
 
+	@Override
+	public Long deleteIssuedPostIdsLessOrEqualLimitTime(final LocalDateTime limitTime) {
+		return queryFactory.delete(postId)
+			.where(postId.createdAt.loe(limitTime))
+			.execute();
+	}
 }

--- a/src/main/java/kr/mywork/interfaces/post/controller/PostController.java
+++ b/src/main/java/kr/mywork/interfaces/post/controller/PostController.java
@@ -35,7 +35,6 @@ import kr.mywork.interfaces.post.controller.dto.response.PostApprovalWebResponse
 import kr.mywork.interfaces.post.controller.dto.response.PostCreateWebResponse;
 import kr.mywork.interfaces.post.controller.dto.response.PostDeleteWebResponse;
 import kr.mywork.interfaces.post.controller.dto.response.PostDetailWebResponse;
-import kr.mywork.interfaces.post.controller.dto.response.PostIdCreateWebResponse;
 import kr.mywork.interfaces.post.controller.dto.response.PostListSelectWebResponse;
 import kr.mywork.interfaces.post.controller.dto.response.PostSelectWebResponse;
 import kr.mywork.interfaces.post.controller.dto.response.PostUpdateWebResponse;
@@ -51,12 +50,6 @@ public class PostController {
 	private static final String POST_APPROVAL_TYPE = "^(APPROVED|PENDING)?$";
 
 	private final PostService postService;
-
-	@PostMapping("/posts/id/generate")
-	public ApiResponse<PostIdCreateWebResponse> createPostId() {
-		final UUID postId = postService.createPostId();
-		return ApiResponse.success(new PostIdCreateWebResponse(postId));
-	}
 
 	@PostMapping("/projects/{project-id}/posts")
 	public ApiResponse<PostCreateWebResponse> createPost(

--- a/src/main/java/kr/mywork/interfaces/post/controller/PostIdController.java
+++ b/src/main/java/kr/mywork/interfaces/post/controller/PostIdController.java
@@ -1,0 +1,28 @@
+package kr.mywork.interfaces.post.controller;
+
+import java.util.UUID;
+
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import kr.mywork.common.api.support.response.ApiResponse;
+import kr.mywork.domain.post.service.PostIdService;
+import kr.mywork.interfaces.post.controller.dto.response.PostIdCreateWebResponse;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("/api")
+@RequiredArgsConstructor
+@Validated
+public class PostIdController {
+
+	private final PostIdService postIdService;
+
+	@PostMapping("/posts/id/generate")
+	public ApiResponse<PostIdCreateWebResponse> createPostId() {
+		final UUID postId = postIdService.createPostId();
+		return ApiResponse.success(new PostIdCreateWebResponse(postId));
+	}
+}

--- a/src/main/java/kr/mywork/interfaces/post/scheduler/PostIdDeleteScheduler.java
+++ b/src/main/java/kr/mywork/interfaces/post/scheduler/PostIdDeleteScheduler.java
@@ -1,0 +1,24 @@
+package kr.mywork.interfaces.post.scheduler;
+
+import java.time.LocalDateTime;
+
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import kr.mywork.domain.post.service.PostIdService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class PostIdDeleteScheduler {
+
+	private final PostIdService postIdService;
+
+	@Scheduled(cron = "${post.issued-id.delete.cron}")
+	public void deleteIssuedPostIds() {
+		final Long deletionCount = postIdService.deleteIssuedPostIds(LocalDateTime.now());
+		log.info("deleted issued post-id count : {}", deletionCount);
+	}
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -52,6 +52,8 @@ post:
     max-count: 3
   issued-id:
     created-limit-hour: 24
+    delete:
+      cron: 0 0 4 * * *
 project:
   page:
     size: 10

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -50,6 +50,8 @@ post:
     endpoint: http://localhost:4566
   attachment:
     max-count: 3
+  issued-id:
+    created-limit-hour: 24
 project:
   page:
     size: 10

--- a/src/test/java/kr/mywork/infrastructure/post/rdb/QueryDslPostIdRepositoryTest.java
+++ b/src/test/java/kr/mywork/infrastructure/post/rdb/QueryDslPostIdRepositoryTest.java
@@ -1,0 +1,37 @@
+package kr.mywork.infrastructure.post.rdb;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.LocalDateTime;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.jdbc.Sql;
+
+import kr.mywork.base.annotations.RdbRepositoryTest;
+import kr.mywork.domain.post.repository.PostIdRepository;
+
+@RdbRepositoryTest(basePackages = {
+	"kr.mywork.infrastructure.post.rdb",
+	"kr.mywork.common.rdb.config"})
+class QueryDslPostIdRepositoryTest {
+
+	@Autowired
+	private PostIdRepository postIdRepository;
+
+	@Test
+	@DisplayName("제한 시간을 지난 날짜의 게시글 아이디 삭제 성공")
+	@Sql("classpath:sql/issued-post-id-bulk-deletion.sql")
+	void 제한_시간을_지난_날짜의_게시글_아이디_삭제_성공 () {
+	    // given
+		final LocalDateTime limitTime = LocalDateTime.of(2025, 6, 30, 16, 0);
+
+	    // when
+		final Long deletionCount = postIdRepository.deleteIssuedPostIdsLessOrEqualLimitTime(limitTime);
+
+		// then
+		assertThat(deletionCount).isEqualTo(4);
+	}
+
+}

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -33,6 +33,10 @@ post:
     endpoint: http://localhost:4566
   attachment:
     max-count: 3
+  issued-id:
+    delete:
+      cron: 0 0 4 * * *
+    created-limit-hour: 24
 project:
   page:
     size: 10

--- a/src/test/resources/sql/issued-post-id-bulk-deletion.sql
+++ b/src/test/resources/sql/issued-post-id-bulk-deletion.sql
@@ -1,0 +1,8 @@
+INSERT INTO post_id (id, created_at)
+VALUES
+    (UUID_TO_BIN('0197bfb8-c256-7099-a01a-d64a9bd5851b'), '2025-06-30 15:30:00'),
+    (UUID_TO_BIN('0197bfba-3e7a-7057-b7f9-b7e19bb9c990'), '2025-06-30 15:40:00'),
+    (UUID_TO_BIN('0197bfba-5db1-759e-824c-a4f093c10342'), '2025-06-30 15:50:00'),
+    (UUID_TO_BIN('0197bfba-a6c5-7607-843f-9de5dd547d91'), '2025-06-30 16:00:00'),
+    (UUID_TO_BIN('0197bfba-e608-7246-adac-9b3552f550ed'), '2025-06-30 16:10:00'),
+    (UUID_TO_BIN('0197bfba-f733-7e82-98a1-df182023b405'), '2025-06-30 16:20:00');

--- a/src/test/resources/sql/post-for-approve.sql
+++ b/src/test/resources/sql/post-for-approve.sql
@@ -17,8 +17,8 @@ VALUES (UUID_TO_BIN('01991f59-6ecf-7a2a-8bb4-92707f10cc0c'),
         '개발', 3, NOW());
 
 
-INSERT INTO post_id
-VALUES (UNHEX(REPLACE('1234a9a9-90b6-9898-a9dc-92c9861aa98c', '-', '')));
+INSERT INTO post_id (id, created_at)
+VALUES (UNHEX(REPLACE('1234a9a9-90b6-9898-a9dc-92c9861aa98c', '-', '')), CURRENT_TIMESTAMP);
 
 INSERT INTO post (id,
                   project_step_id,

--- a/src/test/resources/sql/post-for-delete.sql
+++ b/src/test/resources/sql/post-for-delete.sql
@@ -1,5 +1,5 @@
-INSERT INTO post_id
-VALUES (UNHEX(REPLACE('1234a9a9-90b6-9898-a9dc-92c9861aa98c', '-', '')));
+INSERT INTO post_id (id, created_at)
+VALUES (UNHEX(REPLACE('1234a9a9-90b6-9898-a9dc-92c9861aa98c', '-', '')), CURRENT_TIMESTAMP);
 
 INSERT INTO post (id,
                   project_step_id,

--- a/src/test/resources/sql/post-for-get-list.sql
+++ b/src/test/resources/sql/post-for-get-list.sql
@@ -109,32 +109,32 @@ insert into project_step (project_id, order_num, created_at, id, title)
 values (UNHEX(REPLACE('01975454-e57b-7df5-acb8-598c64aaf54e', '-', '')),2, '2025-06-02 11:10:00', UNHEX(REPLACE('019739d7-54f3-7807-b0c0-d8017fc30c5a', '-', '')), '개발');
 
 -- post_id 테이블에 25개 UUID 삽입
-INSERT INTO post_id VALUES
-    (UNHEX(REPLACE('019739ca-e6ad-7166-b87b-2bd4886f55d7', '-', ''))),
-    (UNHEX(REPLACE('019739ca-e6ad-7751-85fb-0f9f8bc7e742', '-', ''))),
-    (UNHEX(REPLACE('019739ca-e6ad-72ee-9bdd-1b88fac0bb08', '-', ''))),
-    (UNHEX(REPLACE('019739ca-e6ad-7018-a2f2-d21456485685', '-', ''))),
-    (UNHEX(REPLACE('019739ca-e6ad-76a0-aff6-48f13445d6c8', '-', ''))),
-    (UNHEX(REPLACE('019739ca-e6ad-7c39-bf5b-4791155e938b', '-', ''))),
-    (UNHEX(REPLACE('019739ca-e6ad-7d30-aaed-24a437fc2ea3', '-', ''))),
-    (UNHEX(REPLACE('019739ca-e6ad-7234-9c6a-6a4735a8bddc', '-', ''))),
-    (UNHEX(REPLACE('019739ca-e6ad-76b1-9f27-244bf13ab263', '-', ''))),
-    (UNHEX(REPLACE('019739ca-e6ad-717e-8fe1-19aa3400ea9d', '-', ''))),
-    (UNHEX(REPLACE('019739ca-e6ad-73b6-a247-2c5ad94c29b3', '-', ''))),
-    (UNHEX(REPLACE('019739ca-e6ad-7406-ae0f-b2a5cefd4569', '-', ''))),
-    (UNHEX(REPLACE('019739ca-e6ad-72f6-9f30-6fa46e733c06', '-', ''))),
-    (UNHEX(REPLACE('019739ca-e6ad-7fb2-8441-d3417c402491', '-', ''))),
-    (UNHEX(REPLACE('019739ca-e6ad-7b88-b393-fe30946e64ee', '-', ''))),
-    (UNHEX(REPLACE('019739ca-e6ad-7f20-9aa8-6f79275670a8', '-', ''))),
-    (UNHEX(REPLACE('019739ca-e6ad-77cb-8c4b-2f38c456eb3f', '-', ''))),
-    (UNHEX(REPLACE('019739ca-e6ad-7e84-84c7-158621d10c3b', '-', ''))),
-    (UNHEX(REPLACE('019739ca-e6ad-71ea-a780-64b15e3ea214', '-', ''))),
-    (UNHEX(REPLACE('019739ca-e6ad-7f7d-a35e-e5608fe0e141', '-', ''))),
-    (UNHEX(REPLACE('019739ca-e6ad-795d-99c1-23e7fe40f3dd', '-', ''))),
-    (UNHEX(REPLACE('019739ca-e6ad-7702-adfc-79faaddde3c4', '-', ''))),
-    (UNHEX(REPLACE('019739ca-e6ad-7420-b8ec-be8659db84e6', '-', ''))),
-    (UNHEX(REPLACE('019739ca-e6ad-73c4-9b35-e35a81d2390d', '-', ''))),
-    (UNHEX(REPLACE('019739ca-e6ad-7453-9008-b2dc67b222a3', '-', '')));
+INSERT INTO post_id (id, created_at) VALUES
+    (UNHEX(REPLACE('019739ca-e6ad-7166-b87b-2bd4886f55d7', '-', '')), CURRENT_TIMESTAMP),
+    (UNHEX(REPLACE('019739ca-e6ad-7751-85fb-0f9f8bc7e742', '-', '')), CURRENT_TIMESTAMP),
+    (UNHEX(REPLACE('019739ca-e6ad-72ee-9bdd-1b88fac0bb08', '-', '')), CURRENT_TIMESTAMP),
+    (UNHEX(REPLACE('019739ca-e6ad-7018-a2f2-d21456485685', '-', '')), CURRENT_TIMESTAMP),
+    (UNHEX(REPLACE('019739ca-e6ad-76a0-aff6-48f13445d6c8', '-', '')), CURRENT_TIMESTAMP),
+    (UNHEX(REPLACE('019739ca-e6ad-7c39-bf5b-4791155e938b', '-', '')), CURRENT_TIMESTAMP),
+    (UNHEX(REPLACE('019739ca-e6ad-7d30-aaed-24a437fc2ea3', '-', '')), CURRENT_TIMESTAMP),
+    (UNHEX(REPLACE('019739ca-e6ad-7234-9c6a-6a4735a8bddc', '-', '')), CURRENT_TIMESTAMP),
+    (UNHEX(REPLACE('019739ca-e6ad-76b1-9f27-244bf13ab263', '-', '')), CURRENT_TIMESTAMP),
+    (UNHEX(REPLACE('019739ca-e6ad-717e-8fe1-19aa3400ea9d', '-', '')), CURRENT_TIMESTAMP),
+    (UNHEX(REPLACE('019739ca-e6ad-73b6-a247-2c5ad94c29b3', '-', '')), CURRENT_TIMESTAMP),
+    (UNHEX(REPLACE('019739ca-e6ad-7406-ae0f-b2a5cefd4569', '-', '')), CURRENT_TIMESTAMP),
+    (UNHEX(REPLACE('019739ca-e6ad-72f6-9f30-6fa46e733c06', '-', '')), CURRENT_TIMESTAMP),
+    (UNHEX(REPLACE('019739ca-e6ad-7fb2-8441-d3417c402491', '-', '')), CURRENT_TIMESTAMP),
+    (UNHEX(REPLACE('019739ca-e6ad-7b88-b393-fe30946e64ee', '-', '')), CURRENT_TIMESTAMP),
+    (UNHEX(REPLACE('019739ca-e6ad-7f20-9aa8-6f79275670a8', '-', '')), CURRENT_TIMESTAMP),
+    (UNHEX(REPLACE('019739ca-e6ad-77cb-8c4b-2f38c456eb3f', '-', '')), CURRENT_TIMESTAMP),
+    (UNHEX(REPLACE('019739ca-e6ad-7e84-84c7-158621d10c3b', '-', '')), CURRENT_TIMESTAMP),
+    (UNHEX(REPLACE('019739ca-e6ad-71ea-a780-64b15e3ea214', '-', '')), CURRENT_TIMESTAMP),
+    (UNHEX(REPLACE('019739ca-e6ad-7f7d-a35e-e5608fe0e141', '-', '')), CURRENT_TIMESTAMP),
+    (UNHEX(REPLACE('019739ca-e6ad-795d-99c1-23e7fe40f3dd', '-', '')), CURRENT_TIMESTAMP),
+    (UNHEX(REPLACE('019739ca-e6ad-7702-adfc-79faaddde3c4', '-', '')), CURRENT_TIMESTAMP),
+    (UNHEX(REPLACE('019739ca-e6ad-7420-b8ec-be8659db84e6', '-', '')), CURRENT_TIMESTAMP),
+    (UNHEX(REPLACE('019739ca-e6ad-73c4-9b35-e35a81d2390d', '-', '')), CURRENT_TIMESTAMP),
+    (UNHEX(REPLACE('019739ca-e6ad-7453-9008-b2dc67b222a3', '-', '')), CURRENT_TIMESTAMP);
 
 -- post 테이블에 25개 레코드 삽입 (project_step_id는 두 종류로 삽입)
 INSERT INTO post (id, project_step_id, title, company_name, author_name, content, approval, deleted, modified_at, created_at) VALUES

--- a/src/test/resources/sql/post-for-get.sql
+++ b/src/test/resources/sql/post-for-get.sql
@@ -1,5 +1,5 @@
-INSERT INTO post_id
-VALUES (UNHEX(REPLACE('1234a9a9-90b6-9898-a9dc-92c9861aa98c', '-', '')));
+INSERT INTO post_id (id, created_at)
+VALUES (UNHEX(REPLACE('1234a9a9-90b6-9898-a9dc-92c9861aa98c', '-', '')), CURRENT_TIMESTAMP);
 
 INSERT INTO post (id,
                   project_step_id,

--- a/src/test/resources/sql/post-for-update.sql
+++ b/src/test/resources/sql/post-for-update.sql
@@ -1,5 +1,5 @@
-INSERT INTO post_id
-VALUES (UNHEX(REPLACE('1234a9a9-90b6-9898-a9dc-92c9861aa98c', '-', '')));
+INSERT INTO post_id (id, created_at)
+VALUES (UNHEX(REPLACE('1234a9a9-90b6-9898-a9dc-92c9861aa98c', '-', '')), CURRENT_TIMESTAMP);
 
 INSERT INTO post (id,
                   project_step_id,

--- a/src/test/resources/sql/post-id.sql
+++ b/src/test/resources/sql/post-id.sql
@@ -1,1 +1,1 @@
-INSERT INTO post_id VALUES (UNHEX(REPLACE('1234a9a9-90b6-9898-a9dc-92c9861aa98c', '-', '')));
+INSERT INTO post_id (id, created_at) VALUES (UNHEX(REPLACE('1234a9a9-90b6-9898-a9dc-92c9861aa98c', '-', '')), CURRENT_TIMESTAMP);


### PR DESCRIPTION
## 📌 개요

- 게시글 발급 아이디 일괄 삭제 스케줄러 추가

## 🛠️ 변경 사항

- 오전 4시 발급 아이디 일괄 삭제 스케줄러 구성
- 발급 시간 기준 24시간 지난 게시글 발급 아이디 삭제

## ✅ 주요 체크 포인트

- [ ] 일정 시간 기준 일괄 삭제 테스트

## 🔁 테스트 결과

- 스케줄러 구성으로 인한 오전 4시 실행 확인 필요
- 일괄 삭제 레포지토리 삭제 테스트 추가

## 🔗 연관된 이슈

- #285 

<br>

## 📑 레퍼런스

- 없음