### PR TITLE
[feat] 댓글 작성 시 게시글 작성자에게 알림 전송 기능 및 관련 알림 타입 구조 개선(#294)

### DIFF
--- a/src/main/java/kr/mywork/domain/notification/model/NotificationActionType.java
+++ b/src/main/java/kr/mywork/domain/notification/model/NotificationActionType.java
@@ -1,5 +1,5 @@
 package kr.mywork.domain.notification.model;
 
 public enum NotificationActionType {
-	CREATE, MODIFY, DELETE, REJECTED, APPROVED, REQUEST_CHANGES;
+	CREATE, MODIFY, DELETE, REJECTED, APPROVED, REQUEST_CHANGES, REVIEW;
 }

--- a/src/test/java/kr/mywork/docs/ReviewDocumentationTest.java
+++ b/src/test/java/kr/mywork/docs/ReviewDocumentationTest.java
@@ -31,7 +31,7 @@ public class ReviewDocumentationTest extends RestDocsDocumentation {
 
 	@Test
 	@DisplayName("리뷰 생성 테스트 성공")
-	// @Sql("classpath:sql/member-test-users.sql")
+	@Sql("classpath:sql/review-create-test.sql")
 	void 리뷰_생성_테스트_성공() throws Exception {
 		// given
 		final String accessToken = createUserAccessToken();

--- a/src/test/java/kr/mywork/domain/post/service/ReviewServiceTest.java
+++ b/src/test/java/kr/mywork/domain/post/service/ReviewServiceTest.java
@@ -16,21 +16,35 @@ import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import org.springframework.context.ApplicationEventPublisher;
 
+import kr.mywork.domain.notification.repository.NotificationRepository;
+import kr.mywork.domain.notification.service.NotificationService;
+import kr.mywork.domain.post.repository.PostRepository;
 import kr.mywork.domain.post.repository.ReviewRepository;
 import kr.mywork.domain.post.service.dto.ReviewSelectResponse;
+import kr.mywork.domain.project_step.repository.ProjectStepRepository;
 
 class ReviewServiceTest {
 
 	private ReviewService reviewService;
-
 	private ReviewRepository reviewRepository;
-
+	private PostRepository postRepository;
+	private ProjectStepRepository projectStepRepository;
+	private NotificationService notificationService;
 	private ApplicationEventPublisher eventPublisher;
 
 	@BeforeEach
 	void setUp() {
 		this.reviewRepository = Mockito.mock(ReviewRepository.class);
-		this.reviewService = new ReviewService(reviewRepository, eventPublisher);
+		this.postRepository = Mockito.mock(PostRepository.class);
+		this.projectStepRepository = Mockito.mock(ProjectStepRepository.class);
+		this.notificationService = Mockito.mock(NotificationService.class);
+		this.reviewService = new ReviewService(
+			reviewRepository,
+			postRepository,
+			projectStepRepository,
+			notificationService,
+			eventPublisher
+		);
 	}
 
 	@Test

--- a/src/test/resources/sql/review-create-test.sql
+++ b/src/test/resources/sql/review-create-test.sql
@@ -1,0 +1,64 @@
+INSERT INTO member (
+    id, company_id, name, department, position,
+    role, phone_number, email, password, deleted,
+    created_at, modified_at, birth_date
+) VALUES (
+             UUID_TO_BIN('33333333-3333-3333-3333-333333333333'),
+             UUID_TO_BIN('6939d8be-1bf2-4f01-9189-12864e38d913'),
+             '홍길동', '기획팀', '팀장',
+             'ANONYMOUS', '010-1234-5678', 'reviewer@example.com', 'password123', 0,
+             NOW(), NOW(), '1990-01-01 00:00:00'
+         );
+
+INSERT INTO project (
+    id, name, start_at, end_at, step,
+    created_at, modified_at, detail,
+    deleted, project_amount
+) VALUES (
+             UUID_TO_BIN('22222222-2222-2222-2222-222222222222'),
+             '리뷰 테스트용 프로젝트',
+             NOW(), NOW(), 'STEP1',
+             NOW(), NOW(), '리뷰 테스트용 프로젝트입니다.',
+             0, 0
+         );
+
+
+INSERT INTO project_step (id, project_id, title, order_num, created_at)
+VALUES (
+           UUID_TO_BIN('11111111-1111-1111-1111-111111111111'),
+           UUID_TO_BIN('22222222-2222-2222-2222-222222222222'),
+           '기획 단계',
+           1,
+           NOW()
+       );
+
+INSERT INTO post (
+    id, title, content, project_step_id, approval, author_id, author_name,
+    company_name, created_at, modified_at, deleted
+) VALUES (
+             UUID_TO_BIN('01972f9b-232a-7dbe-aad2-3bffc0b78ced'),
+             '리뷰용 게시글',
+             '내용입니다.',
+             UUID_TO_BIN('11111111-1111-1111-1111-111111111111'), -- 프로젝트 스텝 UUID (존재해야 함)
+             'APPROVED',
+             UUID_TO_BIN('33333333-3333-3333-3333-333333333333'), -- authorId (위에서 만든 홍길동)
+             '홍길동',
+             'AUser',
+             NOW(), NOW(), 0
+         );
+
+INSERT INTO review (id, member_id, parent_id, post_id,
+                    company_name, comment, author_name, deleted,
+                    created_at, modified_at)
+VALUES (
+           UUID_TO_BIN('019748f2-244f-702d-aa8c-a7b27d255c2e'),
+           UUID_TO_BIN('33333333-3333-3333-3333-333333333333'),
+           NULL,
+           UUID_TO_BIN('01972f9b-232a-7dbe-aad2-3bffc0b78ced'),
+           'Company01',
+           '기존 리뷰입니다.',
+           '홍길동',
+           b'0',
+           '2025-06-01 12:00:00',
+           '2025-06-01 12:00:00'
+       );


### PR DESCRIPTION
## 📌 개요

게시글에 댓글이 달릴 경우 게시글 작성자에게 알림이 가도록 알림 전송 기능을 추가했습니다. 기존 승인 알림 구조와 동일하게 `NotificationService.save()`를 활용하였습니다.

---

## 🛠️ 변경 사항

* 게시글 댓글 작성 시 게시글 작성자에게 알림 저장 로직 추가
* `NotificationActionType`에 `REVIEW` 타입 추가
* 게시글, 프로젝트 단계 연관 객체 조회 로직 추가
* 자기 자신에게는 알림이 가지 않도록 예외 처리

---

## ✅ 주요 체크 포인트

* [ ] 댓글 저장 시 게시글 작성자와 작성자 본인을 정확히 구분하는 로직
* [ ] 알림 저장 시 `postId`, `projectId`, `projectStepId` 매핑 정확성
* [ ] 기존 알림 로직과의 일관성 유지 여부

---

## 🔁 테스트 결과

* 다른 사용자가 댓글 작성 시 게시글 작성자에게 알림 정상 생성됨
* 댓글 작성자가 게시글 작성자인 경우 알림 생성되지 않음
* 알림 조회 API (`GET /notifications`)에서 해당 알림 정상적으로 노출됨

---

## 🔗 연관된 이슈

* #260
* #294 

---

## 📑 레퍼런스

* 내부 비즈니스 로직에 기반하여 작성됨
