### PR TITLE
feat: 알림 응답 DTO에 isRead 필드 추가(#296)

### DIFF
--- a/src/main/java/kr/mywork/domain/notification/service/dto/response/NotificationSelectResponse.java
+++ b/src/main/java/kr/mywork/domain/notification/service/dto/response/NotificationSelectResponse.java
@@ -25,9 +25,11 @@ public class NotificationSelectResponse {
 	@JsonFormat(pattern = "yyyy-MM-dd HH:mm")
 	private final LocalDateTime actionTime;
 
+	private final boolean isRead;
+
 	public NotificationSelectResponse(UUID id, UUID actorId, String actorName, NotificationActionType actionType,
 		TargetType targetType, UUID targetId, String content,
-		UUID projectId, UUID projectStepId, LocalDateTime actionTime) {
+		UUID projectId, UUID projectStepId, LocalDateTime actionTime, boolean isRead) {
 		this.id = id;
 		this.actorId = actorId;
 		this.actorName = actorName;
@@ -38,5 +40,6 @@ public class NotificationSelectResponse {
 		this.projectId = projectId;
 		this.projectStepId = projectStepId;
 		this.actionTime = actionTime;
+		this.isRead = isRead;
 	}
 }

--- a/src/main/java/kr/mywork/infrastructure/notification/rdb/QueryDslNotificationRepository.java
+++ b/src/main/java/kr/mywork/infrastructure/notification/rdb/QueryDslNotificationRepository.java
@@ -55,7 +55,8 @@ public class QueryDslNotificationRepository implements NotificationRepository {
 				notification.notificationContent,
 				notification.projectId,
 				notification.projectStepId,
-				notification.actionDate
+				notification.actionDate,
+				notification.isRead
 			))
 			.from(notification)
 			.where(

--- a/src/main/java/kr/mywork/interfaces/notification/controller/dto/response/NotificationSelectWebResponse.java
+++ b/src/main/java/kr/mywork/interfaces/notification/controller/dto/response/NotificationSelectWebResponse.java
@@ -9,7 +9,7 @@ import kr.mywork.domain.notification.service.dto.response.NotificationSelectResp
 
 public record NotificationSelectWebResponse (UUID id, UUID actorId, String actorName, String actionType,
 											 String targetType, UUID targetId, String content, UUID projectId, UUID projectStepId,
-											 @JsonFormat(pattern = "yyyy-MM-dd HH:mm") LocalDateTime actionTime) {
+											 @JsonFormat(pattern = "yyyy-MM-dd HH:mm") LocalDateTime actionTime, boolean isRead) {
 
 	public static NotificationSelectWebResponse from(NotificationSelectResponse response) {
 		return new NotificationSelectWebResponse(
@@ -22,7 +22,8 @@ public record NotificationSelectWebResponse (UUID id, UUID actorId, String actor
 			response.getContent(),
 			response.getProjectId(),
 			response.getProjectStepId(),
-			response.getActionTime()
+			response.getActionTime(),
+			response.isRead()
 		);
 	}
 }


### PR DESCRIPTION
## 📌 개요

* 알림 읽음 여부(`isRead`)를 프론트에서 표시할 수 있도록 응답 DTO에 해당 필드를 추가했습니다.

## 🛠️ 변경 사항

* `NotificationSelectResponse` DTO에 `isRead` 필드 추가
* 생성자에 `isRead` 파라미터 추가 및 필드 매핑
* `NotificationSelectWebResponse` DTO에도 `isRead` 필드 추가
* `.from()` 메서드에서 `isRead` 포함하도록 수정

## ✅ 주요 체크 포인트

* [ ] `isRead` 필드가 JSON 응답에 정상적으로 포함되는지
* [ ] 기존 응답 구조가 깨지지 않고 변경에 따라 오류가 없는지

## 🔁 테스트 결과

* API 호출 시 응답 JSON에 `isRead` 필드가 포함되어 정상적으로 반환되는 것 확인
* 기존 알림 목록 조회 API 동작 정상

## 🔗 연관된 이슈

* #260 

## 📑 레퍼런스

* 없음

