### PR TITLE
[feat] 안읽은 알림 개수 조회 API 추가 (#298)

### DIFF
--- a/src/main/java/kr/mywork/domain/notification/repository/NotificationRepository.java
+++ b/src/main/java/kr/mywork/domain/notification/repository/NotificationRepository.java
@@ -12,4 +12,6 @@ public interface NotificationRepository {
 	List<NotificationSelectResponse> findByConditionWithPaging(int page, Boolean isRead, UUID memberId);
 
 	Notification findById(UUID id);
+
+	long countByMemberIdAndIsReadFalse(UUID memberId);
 }

--- a/src/main/java/kr/mywork/domain/notification/service/NotificationService.java
+++ b/src/main/java/kr/mywork/domain/notification/service/NotificationService.java
@@ -41,4 +41,9 @@ public class NotificationService {
 		notification.markAsRead();
 		return new NotificationReadResponse(notification.getId());
 	}
+
+	public long countUnreadNotifications(UUID memberId) {
+		return notificationRepository.countByMemberIdAndIsReadFalse(memberId);
+	}
+
 }

--- a/src/main/java/kr/mywork/infrastructure/notification/rdb/QueryDslNotificationRepository.java
+++ b/src/main/java/kr/mywork/infrastructure/notification/rdb/QueryDslNotificationRepository.java
@@ -76,4 +76,17 @@ public class QueryDslNotificationRepository implements NotificationRepository {
 
 		return notification.isRead.eq(isRead);
 	}
+
+	@Override
+	public long countByMemberIdAndIsReadFalse(UUID memberId) {
+		return queryFactory
+			.select(notification.count())
+			.from(notification)
+			.where(
+				notification.receiverMemberId.eq(memberId),
+				notification.isRead.isFalse()
+			)
+			.fetchOne();
+	}
+
 }

--- a/src/main/java/kr/mywork/interfaces/notification/controller/NotificationController.java
+++ b/src/main/java/kr/mywork/interfaces/notification/controller/NotificationController.java
@@ -60,4 +60,9 @@ public class NotificationController {
 		return ApiResponse.success(new NotificationReadWebResponse(notificationReadResponse.getId()));
 	}
 
+	@GetMapping("/unread-count")
+	public ApiResponse<Long> getUnreadNotificationCount(@LoginMember LoginMemberDetail loginMemberDetail) {
+		long count = notificationService.countUnreadNotifications(loginMemberDetail.memberId());
+		return ApiResponse.success(count);
+	}
 }


### PR DESCRIPTION
## 📌 개요

* 사용자의 읽지 않은 알림 개수를 조회할 수 있는 API를 구현했습니다.
* 사이드바나 헤더 등에서 뱃지로 표시할 수 있도록 프론트와 연동될 예정입니다.

## 🛠️ 변경 사항

* GET `/api/notifications/unread-count` API 엔드포인트 추가
* `NotificationService`에 `countUnreadNotifications()` 메서드 구현
* `NotificationRepository`에 `countByMemberIdAndIsReadFalse()` 메서드 추가
* 로그인한 사용자의 읽지 않은 알림 개수를 반환

## ✅ 주요 체크 포인트

* [ ] 인증된 사용자의 ID를 기준으로 count 조회
* [ ] 응답 형식이 `ApiResponse<Long>` 형태로 반환되는지 확인

## 🔁 테스트 결과

* Postman으로 테스트 시, 로그인 사용자 기준으로 알림 테이블의 isRead = false 개수가 정확히 반환됨

## 🔗 연관된 이슈

* #298 
* #296 
* #294 
* #260 


## 📑 레퍼런스

* 없음 
