### PR TITLE
[bug]  프로젝트 스탭 갯수 조회시 삭제된건은 제외

### DIFF
--- a/src/main/java/kr/mywork/infrastructure/post/rdb/QueryDslPostRepository.java
+++ b/src/main/java/kr/mywork/infrastructure/post/rdb/QueryDslPostRepository.java
@@ -225,7 +225,8 @@ public class QueryDslPostRepository implements PostRepository {
 				post.count()
 			))
 			.from(post)
-			.where(post.projectStepId.in(projectStepIds))
+			.where(post.projectStepId.in(projectStepIds),
+					post.deleted.eq(false))
 			.groupBy(post.projectStepId)
 			.fetch();
 	}


### PR DESCRIPTION
## 📌 개요

- 프로젝트 스탭 갯수 조회시 삭제된건은 제외

## 🛠️ 변경 사항
-  프로젝트 스탭 갯수 조회시 삭제된건은 제외

## ✅ 주요 체크 포인트

- [ ] 게시글 삭제시 프로젝트 스탭의 갯수 줄어드는지 확인.


## 🔁 테스트 결과
화면 테스트

## 🔗 연관된 이슈
#305 
