### PR TITLE
[fix] 알림 게시글 상태 변경시 상태 변경에 관한 알림 타입 전달

### DIFF
--- a/src/main/java/kr/mywork/domain/notification/model/NotificationActionType.java
+++ b/src/main/java/kr/mywork/domain/notification/model/NotificationActionType.java
@@ -1,5 +1,5 @@
 package kr.mywork.domain.notification.model;
 
 public enum NotificationActionType {
-	CREATE, MODIFY, DELETE, REJECTED, APPROVED, REQUEST_CHANGES, REVIEW;
+	CREATE, MODIFY, DELETE, REJECTED, APPROVED, REQUEST_CHANGES, REVIEW, PENDING;
 }

--- a/src/main/java/kr/mywork/domain/post/listener/PostApprovalAlarmTxListener.java
+++ b/src/main/java/kr/mywork/domain/post/listener/PostApprovalAlarmTxListener.java
@@ -1,0 +1,30 @@
+package kr.mywork.domain.post.listener;
+
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+import kr.mywork.domain.notification.service.NotificationService;
+import kr.mywork.domain.post.listener.event.PostApprovalAlarmEvent;
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class PostApprovalAlarmTxListener {
+
+	private final NotificationService notificationService;
+
+	@Transactional(propagation = Propagation.REQUIRES_NEW)
+	@Async("eventTaskExecutor")
+	@TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+	public void handlePostApprovalAlarmEvent(final PostApprovalAlarmEvent event) {
+
+		notificationService.save(
+			event.authorId(), event.authorName(), event.postTitle(), event.memberName(), event.memberId(),
+			event.targetType(), event.postId(), event.notificationActionType(), event.modifiedAt(), event.projectId(),
+			event.projectStepId());
+	}
+}

--- a/src/main/java/kr/mywork/domain/post/listener/event/PostApprovalAlarmEvent.java
+++ b/src/main/java/kr/mywork/domain/post/listener/event/PostApprovalAlarmEvent.java
@@ -1,0 +1,13 @@
+package kr.mywork.domain.post.listener.event;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+import kr.mywork.domain.notification.model.NotificationActionType;
+import kr.mywork.domain.notification.model.TargetType;
+
+public record PostApprovalAlarmEvent(UUID authorId, String authorName, String postTitle, UUID memberId,
+									 String memberName, TargetType targetType, UUID postId,
+									 NotificationActionType notificationActionType, LocalDateTime modifiedAt,
+									 UUID projectId, UUID projectStepId) {
+}

--- a/src/main/java/kr/mywork/domain/post/model/Post.java
+++ b/src/main/java/kr/mywork/domain/post/model/Post.java
@@ -19,6 +19,8 @@ import lombok.NoArgsConstructor;
 @Getter
 public class Post {
 
+	private static final String APPROVED = "APPROVED";
+
 	@Id
 	private UUID id;
 
@@ -90,5 +92,9 @@ public class Post {
 
 	public boolean isDeleted() {
 		return this.deleted;
+	}
+
+	public boolean isApproved() {
+		return this.approval.equals(APPROVED);
 	}
 }

--- a/src/main/java/kr/mywork/domain/post/service/PostService.java
+++ b/src/main/java/kr/mywork/domain/post/service/PostService.java
@@ -80,7 +80,7 @@ public class PostService {
 			loginMemberDetail.memberId(),
 			TargetType.POST,
 			post.getId(),
-			NotificationActionType.APPROVED,
+			post.isApproved() ? NotificationActionType.APPROVED : NotificationActionType.PENDING,
 			post.getModifiedAt(),
 			projectStep.getProjectId(),
 			projectStep.getId()

--- a/src/main/java/kr/mywork/interfaces/post/controller/dto/request/PostApprovalWebRequest.java
+++ b/src/main/java/kr/mywork/interfaces/post/controller/dto/request/PostApprovalWebRequest.java
@@ -1,5 +1,6 @@
 package kr.mywork.interfaces.post.controller.dto.request;
 
+import jakarta.validation.constraints.Pattern;
 import kr.mywork.domain.post.service.dto.response.PostApprovalRequest;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -7,6 +8,10 @@ import lombok.Getter;
 @Getter
 @AllArgsConstructor
 public class PostApprovalWebRequest {
+
+	private static final String POST_APPROVAL_TYPE = "^(APPROVED|PENDING)?$";
+
+	@Pattern(regexp = POST_APPROVAL_TYPE, message = "{invalid.post-approval-type}")
 	private String approvalStatus;
 
 	public PostApprovalRequest toServiceDto() {


### PR DESCRIPTION
## 📌 개요

- 알림 게시글 상태 변경시 상태 변경에 관한 알림 타입 전달

## 🛠️ 변경 사항

- 대기 변경 시 대기 타입에 관한 알람 이벤트 발행
- 게시글 승인 로직 성공 시 트랜잭션 분리

## ✅ 주요 체크 포인트

- [ ] 정상 동작 여부 확인 필요

## 🔁 테스트 결과



## 🔗 연관된 이슈

- #308 

<br>

## 📑 레퍼런스

- 없음