### PR TITLE
[fix] 고객사 어드민 대시보드 접근 시 5일 이내 대시보드에서 6일 이전 내용이 조회되는 문제

### DIFF
--- a/src/main/java/kr/mywork/domain/auth/service/TokenAuthenticationService.java
+++ b/src/main/java/kr/mywork/domain/auth/service/TokenAuthenticationService.java
@@ -23,7 +23,7 @@ public class TokenAuthenticationService {
 		String email = claims.get("email", String.class);
 		String role = claims.get("role", String.class);
 		String name = claims.get("name", String.class);
-		MemberRole memberRole = MemberRole.of(role);
+		MemberRole memberRole = MemberRole.fromRoleName(role);
 		UUID companyId = UUID.fromString(claims.get("companyId", String.class));
 		String companyName = claims.get("companyName", String.class);
 		String logoImagePath = claims.get("logoImagePath", String.class);

--- a/src/main/java/kr/mywork/domain/member/model/Member.java
+++ b/src/main/java/kr/mywork/domain/member/model/Member.java
@@ -71,7 +71,7 @@ public class Member {
 		this.name = name;
 		this.department = department;
 		this.position = position;
-		this.role = MemberRole.from(role);
+		this.role = MemberRole.fromName(role);
 		this.phoneNumber = phoneNumber;
 		this.email = email;
 		this.password = password;
@@ -108,7 +108,7 @@ public class Member {
 		this.name = name;
 		this.department = department;
 		this.position = position;
-		this.role = MemberRole.from(role);
+		this.role = MemberRole.fromName(role);
 		this.phoneNumber = phoneNumber;
 		this.email = email;
 		this.birthDate = birthDate;

--- a/src/main/java/kr/mywork/domain/member/model/MemberRole.java
+++ b/src/main/java/kr/mywork/domain/member/model/MemberRole.java
@@ -18,16 +18,16 @@ public enum MemberRole {
 
 	private final String roleName;
 
-	public static MemberRole of(final String inputRole) {
+	public static MemberRole fromRoleName(final String inputRoleName) {
 		return Arrays.stream(values())
-			.filter(role -> role.getRoleName().equalsIgnoreCase(inputRole))
+			.filter(role -> role.getRoleName().equalsIgnoreCase(inputRoleName))
 			.findFirst()
-			.orElseThrow(() -> new IllegalArgumentException("invalid role name: " + inputRole));
+			.orElseThrow(() -> new MemberTypeNotFoundException(MemberErrorType.TYPE_NOT_FOUND));
 	}
 
-	public static MemberRole from(String value) {
+	public static MemberRole fromName(final String name) {
 		return Arrays.stream(MemberRole.values())
-			.filter(memberRole -> memberRole.name().equals(value))
+			.filter(memberRole -> memberRole.name().equals(name))
 			.findAny()
 			.orElseThrow(() -> new MemberTypeNotFoundException(MemberErrorType.TYPE_NOT_FOUND));
 	}

--- a/src/main/java/kr/mywork/domain/project/service/ProjectDashBoardService.java
+++ b/src/main/java/kr/mywork/domain/project/service/ProjectDashBoardService.java
@@ -1,0 +1,300 @@
+package kr.mywork.domain.project.service;
+
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.YearMonth;
+import java.time.temporal.ChronoField;
+import java.time.temporal.ChronoUnit;
+import java.time.temporal.TemporalAdjusters;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import kr.mywork.common.auth.components.dto.LoginMemberDetail;
+import kr.mywork.domain.dashboard.service.dto.response.DashboardCountSummaryResponse;
+import kr.mywork.domain.dashboard.service.dto.response.DashboardPopularProjectsResponse;
+import kr.mywork.domain.member.errors.MemberErrorType;
+import kr.mywork.domain.member.errors.MemberTypeNotFoundException;
+import kr.mywork.domain.member.model.MemberRole;
+import kr.mywork.domain.post.repository.PostRepository;
+import kr.mywork.domain.project.model.Project;
+import kr.mywork.domain.project.model.ProjectAmountChartRole;
+import kr.mywork.domain.project.model.ProjectAssign;
+import kr.mywork.domain.project.model.ProjectMember;
+import kr.mywork.domain.project.repository.ProjectAssignRepository;
+import kr.mywork.domain.project.repository.ProjectRepository;
+import kr.mywork.domain.project.service.dto.request.NearDeadlineProjectRequest;
+import kr.mywork.domain.project.service.dto.response.DashboardMostPostProjectResponse;
+import kr.mywork.domain.project.service.dto.response.NearDeadlineProjectResponse;
+import kr.mywork.domain.project.service.dto.response.ProjectAmountSummaryResponse;
+import kr.mywork.domain.project_member.repository.ProjectMemberRepository;
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class ProjectDashBoardService {
+
+	@Value("${dashboard.page.size}")
+	private int dashboardPageSize;
+
+	private final ProjectRepository projectRepository;
+	private final PostRepository postRepository;
+	private final ProjectAssignRepository projectAssignRepository;
+	private final ProjectMemberRepository projectMemberRepository;
+
+	@Transactional(readOnly = true)
+	public DashboardCountSummaryResponse getSummaryTotalCount(LoginMemberDetail loginMemberDetail) {
+
+		final String userType = loginMemberDetail.roleName();
+		final UUID companyId = loginMemberDetail.companyId();
+		final UUID memberId = loginMemberDetail.memberId();
+
+		if (MemberRole.SYSTEM_ADMIN.isSameRoleName(userType)) {
+
+			return fetchProjectSummaryByProjectIds(null);
+
+		} else if (MemberRole.DEV_ADMIN.isSameRoleName(userType) || MemberRole.CLIENT_ADMIN.isSameRoleName(userType)
+			&& companyId != null) {
+
+			final List<UUID> projectIds = projectAssignRepository.getCompanyAdminProjectIds(companyId, userType).stream()
+				.map(ProjectAssign::getProjectId)
+				.toList();
+
+			return fetchProjectSummaryByProjectIds(projectIds);
+
+		} else if (MemberRole.USER.isSameRoleName(userType) && memberId != null) {
+
+			final List<UUID> projectIds = projectMemberRepository.getUserProjectIds(memberId).stream()
+				.map(ProjectMember::getProjectId)
+				.toList();
+
+			return fetchProjectSummaryByProjectIds(projectIds);
+
+		} else {
+			throw new MemberTypeNotFoundException(MemberErrorType.TYPE_NOT_FOUND);
+		}
+	}
+
+	private DashboardCountSummaryResponse fetchProjectSummaryByProjectIds(List<UUID> projectIds){
+		LocalDateTime now = LocalDateTime.now();
+
+		Long totalCount = projectRepository.getSummaryProjectTotalCount(projectIds);
+		Long inProgressCount = projectRepository.getSummaryInProgressProjectTotalCount(projectIds, now);
+		Long completedCount = projectRepository.getSummaryCompletedProjectTotalCount(projectIds, now);
+
+		return new DashboardCountSummaryResponse(totalCount, inProgressCount, completedCount);
+	}
+
+	@Transactional
+	public List<DashboardPopularProjectsResponse> getMostPostProjectsTopFive(LoginMemberDetail memberDetail) {
+		final String memberRole = memberDetail.roleName();
+		//가져온 프로젝트들의 ID에 이름을 과 순서를 매칭 해주는 메소드 [ buildPopularResponse ]
+		if(MemberRole.SYSTEM_ADMIN.isSameRoleName(memberRole)){
+			return buildPopularResponse(postRepository.findMostPostProjectTopFive(null));
+		}
+		if(MemberRole.CLIENT_ADMIN.isSameRoleName(memberRole) || MemberRole.DEV_ADMIN.isSameRoleName(memberRole)){
+			final UUID companyId = memberDetail.companyId(); //회사 기준으로 -> 프로젝트 ID들 가져와야함.
+			final List<UUID> companyProjectIds = projectAssignRepository.findCompanyProjectsByCompanyId(companyId,memberRole);
+
+			return buildPopularResponse(postRepository.findMostPostProjectTopFive(companyProjectIds));
+		}
+		if(MemberRole.USER.isSameRoleName(memberRole)){
+			UUID memberId = memberDetail.memberId(); //멤버 아이디 기준으로 프로젝트 ID를 가져와야함
+			final List<UUID> memberProjectIds = projectMemberRepository.findProjectIdsByMemberId(memberId);
+
+			return buildPopularResponse(postRepository.findMostPostProjectTopFive(memberProjectIds));
+		}
+		throw new MemberTypeNotFoundException(MemberErrorType.TYPE_NOT_FOUND);
+	}
+
+	private List<DashboardPopularProjectsResponse> buildPopularResponse(List<DashboardMostPostProjectResponse> mostPostProjects) {
+		List<UUID> ids = mostPostProjects.stream()
+			.map(DashboardMostPostProjectResponse::projectId)
+			.toList();
+		//프로젝트들의 ID 이름을 가져온다.
+		List<Project> popularProjects = projectRepository.findProjectsNameById(ids);
+		//리스트를 맵형태로 전환
+		Map<UUID, Project> projectMap = popularProjects.stream()
+			.collect(Collectors.toMap(Project::getId, p -> p));
+		//리스트에 값을 맵에서 찾아서 맵핑
+		return mostPostProjects.stream()
+			.map(dto -> {
+				Project p = projectMap.get(dto.projectId());
+				return new DashboardPopularProjectsResponse(p.getId(), p.getName(), dto.postCount());
+			})
+			.toList();
+	}
+
+	@Transactional(readOnly = true)
+	public List<NearDeadlineProjectResponse> findNearDeadlineProjectsByLoginMember(
+		final int page,
+		final NearDeadlineProjectRequest nearDeadlineProjectRequest,
+		final LocalDate baseDate
+	) {
+		final String userType = nearDeadlineProjectRequest.getMemberRole();
+		final LocalDateTime now = baseDate.atStartOfDay();
+
+		if (MemberRole.SYSTEM_ADMIN.getRoleName().equals(userType)) {
+			final List<Project> projects = projectRepository.findAllNearDeadlineProjects(page, dashboardPageSize, baseDate);
+			return projects.stream()
+				.map(this::toResponseWithDday)
+				.toList();
+		}
+
+		if (MemberRole.CLIENT_ADMIN.getRoleName().equals(userType) || MemberRole.DEV_ADMIN.getRoleName().equals(userType)) {
+			final UUID companyId = nearDeadlineProjectRequest.getCompanyId();
+			final List<ProjectAssign> assigns = projectAssignRepository.findAllByCompanyId(companyId, userType);
+			final List<UUID> projectIds = assigns.stream()
+				.map(ProjectAssign::getProjectId)
+				.distinct()
+				.toList();
+
+			final List<Project> projects = projectRepository.findAllNearDeadlineProjectsByProjectIds(projectIds, page, dashboardPageSize, now);
+			return projects.stream()
+				.map(this::toResponseWithDday)
+				.toList();
+		}
+
+		final UUID memberId = nearDeadlineProjectRequest.getMemberId();
+		final List<ProjectMember> projectMembers = projectMemberRepository.findAllByMemberId(memberId);
+		final List<UUID> projectIds = projectMembers.stream()
+			.map(ProjectMember::getProjectId)
+			.distinct()
+			.toList();
+
+		final List<Project> projects = projectRepository.findAllNearDeadlineProjectsByProjectIds(projectIds, page, dashboardPageSize, now);
+		return projects.stream()
+			.map(this::toResponseWithDday)
+			.toList();
+	}
+
+	private NearDeadlineProjectResponse toResponseWithDday(Project project) {
+		int dday = Math.max(0, (int) ChronoUnit.DAYS.between(LocalDate.now(), project.getEndAt().toLocalDate()));
+		return NearDeadlineProjectResponse.of(project.getId(), project.getName(), project.getEndAt(), dday);
+	}
+
+	@Transactional(readOnly = true)
+	public Long countNearDeadlineProjectsByLoginMember(final NearDeadlineProjectRequest nearDeadlineProjectRequest, final LocalDate baseDate) {
+		final String memberRole = nearDeadlineProjectRequest.getMemberRole();
+
+		if (MemberRole.SYSTEM_ADMIN.getRoleName().equals(memberRole)) {
+			return projectRepository.countNearDeadlineProjects(baseDate);
+		}
+
+		if (MemberRole.CLIENT_ADMIN.getRoleName().equals(memberRole) || MemberRole.DEV_ADMIN.getRoleName().equals(
+			memberRole)) {
+			final UUID companyId = nearDeadlineProjectRequest.getCompanyId();
+			final List<ProjectAssign> assigns = projectAssignRepository.findAllByCompanyId(companyId, memberRole);
+			final List<UUID> projectIds = assigns.stream()
+				.map(ProjectAssign::getProjectId)
+				.toList();
+
+			return projectRepository.countNearDeadlineProjectsByProjectIds(projectIds, baseDate);
+		}
+
+		final UUID memberId = nearDeadlineProjectRequest.getMemberId();
+		final List<ProjectMember> projectMembers = projectMemberRepository.findAllByMemberId(memberId);
+		final List<UUID> projectIds = projectMembers.stream()
+			.map(ProjectMember::getProjectId)
+			.distinct()
+			.toList();
+
+		return projectRepository.countNearDeadlineProjectsByProjectIds(projectIds, baseDate);
+	}
+
+	@Transactional
+	public List<ProjectAmountSummaryResponse> findProjectAmountSummary(LoginMemberDetail memberDetail, String chartType, LocalDate today) {
+		//로그인한 유저의 타입별로 프로젝트 Ids를 반환Add commentMore actions
+		final List<UUID> projectIds = getProjectIdsByRoleName(memberDetail);
+		String status = "COMPLETED";
+
+		if (ProjectAmountChartRole.CHART_WEEK.isSameChartType(chartType)) {
+			//프로젝트 조회 (1달전의 주의 첫날 월요일 기준)
+			LocalDate oneMonthAgo = today.minusMonths(1);
+			LocalDate startOfWeek = oneMonthAgo.with(TemporalAdjusters.previousOrSame(DayOfWeek.SUNDAY));
+			LocalDateTime startDate = startOfWeek.atStartOfDay();
+
+			//프로젝트 날짜 기준으로 조회.
+			final List<Project> projects = projectRepository.findCompletedProjectsByIdsWithDate(projectIds, startDate,status);
+
+			List<ProjectAmountSummaryResponse> result = new ArrayList<>();
+
+			for (int i = 3; i >= 0; i--) {
+				LocalDateTime weekStart = startDate.plusWeeks(i);
+				//반복문은 7씩 증가 하지만 종료일은 오늘기준으로 가야함
+				LocalDateTime weekEnd = (i < 3) ? startDate.plusWeeks(i + 1) : today.atStartOfDay();
+				// 계산 통계 합계
+				long totalAmount = projects.stream()
+					.filter(project -> {
+						LocalDateTime endAt = project.getEndAt();
+						return !endAt.isBefore(weekStart) && endAt.isBefore(weekEnd);
+					})
+					.mapToLong(Project::getProjectAmount)
+					.sum();
+
+				//몇월인지 구함
+				int month = weekStart.getMonthValue();
+				//몇째 주 인지 구함
+				int weekOfMonth = weekStart.get(ChronoField.ALIGNED_WEEK_OF_MONTH);
+				String label = month + "월" + weekOfMonth + "주";
+
+				result.add(new ProjectAmountSummaryResponse(label, totalAmount));
+			}
+			return result;
+		}
+
+		if (ProjectAmountChartRole.CHART_MONTH.isSameChartType(chartType)) {
+			//프로젝트 월초 6개월 치 데이터
+			YearMonth sixMonthAgo = YearMonth.from(today).minusMonths(5);
+			LocalDate startOfMonth = sixMonthAgo.atDay(1);
+			LocalDateTime startDate = startOfMonth.atStartOfDay();
+			//프로젝트 날짜 기준으로 조회.
+			final List<Project> projects = projectRepository.findCompletedProjectsByIdsWithDate(projectIds, startDate,status);
+
+			List<ProjectAmountSummaryResponse> result = new ArrayList<>();
+
+
+			for (int i = 5; i >= 0; i--) {
+				YearMonth targetMonth = YearMonth.from(today).minusMonths(i);
+				LocalDateTime monthStart = targetMonth.atDay(1).atStartOfDay();            // 월의 시작일
+				LocalDateTime monthEnd = targetMonth.atEndOfMonth().plusDays(1).atStartOfDay(); // 다음 달 1일 00:00
+
+				// 계산 통계 합계
+				long totalAmount = projects.stream()
+					.filter(project -> {
+						LocalDateTime endAt = project.getEndAt();
+						return !endAt.isBefore(monthStart) && endAt.isBefore(monthEnd);
+					})
+					.mapToLong(Project::getProjectAmount)
+					.sum();
+
+				//몇월인지 구함
+				String label = targetMonth.getMonthValue() + "월";
+
+				result.add(new ProjectAmountSummaryResponse(label, totalAmount));
+			}
+			return result;
+
+		}
+		return Collections.emptyList();
+	}
+
+	private List<UUID> getProjectIdsByRoleName(LoginMemberDetail memberDetail) {
+		String roleName = memberDetail.roleName();
+		if (MemberRole.CLIENT_ADMIN.isSameRoleName(roleName) || MemberRole.DEV_ADMIN.isSameRoleName(roleName)) {
+			return projectAssignRepository.findCompanyProjectsByCompanyId(memberDetail.companyId(), roleName);
+		} else if (MemberRole.USER.isSameRoleName(roleName)) {
+			return projectMemberRepository.findProjectIdsByMemberId(memberDetail.memberId());
+		} else {
+			throw new MemberTypeNotFoundException(MemberErrorType.TYPE_NOT_FOUND);
+		}
+	}
+}

--- a/src/main/java/kr/mywork/domain/project/service/ProjectService.java
+++ b/src/main/java/kr/mywork/domain/project/service/ProjectService.java
@@ -1,5 +1,16 @@
 package kr.mywork.domain.project.service;
 
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
 import kr.mywork.common.auth.components.dto.LoginMemberDetail;
 import kr.mywork.domain.activityLog.listener.eventObject.CreateEventObject;
 import kr.mywork.domain.activityLog.listener.eventObject.DeleteEventObject;
@@ -9,8 +20,6 @@ import kr.mywork.domain.company.errors.CompanyNotFoundException;
 import kr.mywork.domain.company.model.Company;
 import kr.mywork.domain.company.model.CompanyType;
 import kr.mywork.domain.company.repository.CompanyRepository;
-import kr.mywork.domain.dashboard.service.dto.response.DashboardCountSummaryResponse;
-import kr.mywork.domain.dashboard.service.dto.response.DashboardPopularProjectsResponse;
 import kr.mywork.domain.member.errors.MemberErrorType;
 import kr.mywork.domain.member.errors.MemberTypeNotFoundException;
 import kr.mywork.domain.member.model.Member;
@@ -22,31 +31,18 @@ import kr.mywork.domain.project.errors.ProjectAssignNotFoundException;
 import kr.mywork.domain.project.errors.ProjectErrorType;
 import kr.mywork.domain.project.errors.ProjectNotFoundException;
 import kr.mywork.domain.project.model.Project;
-import kr.mywork.domain.project.model.ProjectAmountChartRole;
 import kr.mywork.domain.project.model.ProjectAssign;
-import kr.mywork.domain.project.model.ProjectMember;
 import kr.mywork.domain.project.repository.ProjectAssignRepository;
 import kr.mywork.domain.project.repository.ProjectRepository;
-import kr.mywork.domain.project.service.dto.request.NearDeadlineProjectRequest;
 import kr.mywork.domain.project.service.dto.request.ProjectCreateRequest;
 import kr.mywork.domain.project.service.dto.request.ProjectUpdateRequest;
-import kr.mywork.domain.project.service.dto.response.*;
+import kr.mywork.domain.project.service.dto.response.MyProjectSelectResponse;
+import kr.mywork.domain.project.service.dto.response.ProjectDetailResponse;
+import kr.mywork.domain.project.service.dto.response.ProjectMemberResponse;
+import kr.mywork.domain.project.service.dto.response.ProjectSelectResponse;
+import kr.mywork.domain.project.service.dto.response.ProjectUpdateResponse;
 import kr.mywork.domain.project_member.repository.ProjectMemberRepository;
 import lombok.RequiredArgsConstructor;
-import org.springframework.beans.factory.annotation.Value;
-import org.springframework.context.ApplicationEventPublisher;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
-
-import java.time.DayOfWeek;
-import java.time.LocalDate;
-import java.time.LocalDateTime;
-import java.time.YearMonth;
-import java.time.temporal.ChronoField;
-import java.time.temporal.ChronoUnit;
-import java.time.temporal.TemporalAdjusters;
-import java.util.*;
-import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -58,9 +54,6 @@ public class ProjectService {
 
 	@Value("${project.page.size}")
 	private int projectPageSize;
-
-	@Value("${dashboard.page.size}")
-	private int dashboardPageSize;
 
 	private final ProjectRepository projectRepository;
 	private final ProjectAssignRepository projectAssignRepository;
@@ -321,123 +314,6 @@ public class ProjectService {
 	}
 
 	@Transactional
-	public List<DashboardPopularProjectsResponse> getMostPostProjectsTopFive(LoginMemberDetail memberDetail) {
-		final String memberRole = memberDetail.roleName();
-		//가져온 프로젝트들의 ID에 이름을 과 순서를 매칭 해주는 메소드 [ buildPopularResponse ]
-		if(MemberRole.SYSTEM_ADMIN.isSameRoleName(memberRole)){
-			return buildPopularResponse(postRepository.findMostPostProjectTopFive(null));
-		}
-		if(MemberRole.CLIENT_ADMIN.isSameRoleName(memberRole) || MemberRole.DEV_ADMIN.isSameRoleName(memberRole)){
-			final UUID companyId = memberDetail.companyId(); //회사 기준으로 -> 프로젝트 ID들 가져와야함.
-			final List<UUID> companyProjectIds = projectAssignRepository.findCompanyProjectsByCompanyId(companyId,memberRole);
-
-			return buildPopularResponse(postRepository.findMostPostProjectTopFive(companyProjectIds));
-		}
-		if(MemberRole.USER.isSameRoleName(memberRole)){
-			UUID memberId = memberDetail.memberId(); //멤버 아이디 기준으로 프로젝트 ID를 가져와야함
-			final List<UUID> memberProjectIds = projectMemberRepository.findProjectIdsByMemberId(memberId);
-
-			return buildPopularResponse(postRepository.findMostPostProjectTopFive(memberProjectIds));
-		}
-		throw new MemberTypeNotFoundException(MemberErrorType.TYPE_NOT_FOUND);
-
-	}
-	private List<DashboardPopularProjectsResponse> buildPopularResponse(List<DashboardMostPostProjectResponse> mostPostProjects) {
-		List<UUID> ids = mostPostProjects.stream()
-				.map(DashboardMostPostProjectResponse::projectId)
-				.toList();
-		//프로젝트들의 ID 이름을 가져온다.
-		List<Project> popularProjects = projectRepository.findProjectsNameById(ids);
-		//리스트를 맵형태로 전환
-		Map<UUID, Project> projectMap = popularProjects.stream()
-			.collect(Collectors.toMap(Project::getId, p -> p));
-		//리스트에 값을 맵에서 찾아서 맵핑
-		return mostPostProjects.stream()
-			.map(dto -> {
-				Project p = projectMap.get(dto.projectId());
-				return new DashboardPopularProjectsResponse(p.getId(), p.getName(), dto.postCount());
-			})
-			.toList();
-	}
-
-	@Transactional(readOnly = true)
-	public List<NearDeadlineProjectResponse> findNearDeadlineProjectsByLoginMember(
-		final int page,
-		final NearDeadlineProjectRequest nearDeadlineProjectRequest,
-		final LocalDate baseDate
-	) {
-		final String userType = nearDeadlineProjectRequest.getMemberRole();
-		final LocalDateTime now = baseDate.atStartOfDay();
-
-		if (MemberRole.SYSTEM_ADMIN.getRoleName().equals(userType)) {
-			final List<Project> projects = projectRepository.findAllNearDeadlineProjects(page, dashboardPageSize, baseDate);
-			return projects.stream()
-				.map(this::toResponseWithDday)
-				.toList();
-		}
-
-		if (MemberRole.CLIENT_ADMIN.getRoleName().equals(userType) || MemberRole.DEV_ADMIN.getRoleName().equals(userType)) {
-			final UUID companyId = nearDeadlineProjectRequest.getCompanyId();
-			final List<ProjectAssign> assigns = projectAssignRepository.findAllByCompanyId(companyId, userType);
-			final List<UUID> projectIds = assigns.stream()
-				.map(ProjectAssign::getProjectId)
-				.distinct()
-				.toList();
-
-			final List<Project> projects = projectRepository.findAllNearDeadlineProjectsByProjectIds(projectIds, page, dashboardPageSize, now);
-			return projects.stream()
-				.map(this::toResponseWithDday)
-				.toList();
-		}
-
-		final UUID memberId = nearDeadlineProjectRequest.getMemberId();
-		final List<ProjectMember> projectMembers = projectMemberRepository.findAllByMemberId(memberId);
-		final List<UUID> projectIds = projectMembers.stream()
-			.map(ProjectMember::getProjectId)
-			.distinct()
-			.toList();
-
-		final List<Project> projects = projectRepository.findAllNearDeadlineProjectsByProjectIds(projectIds, page, dashboardPageSize, now);
-		return projects.stream()
-			.map(this::toResponseWithDday)
-			.toList();
-	}
-
-	private NearDeadlineProjectResponse toResponseWithDday(Project project) {
-		int dday = Math.max(0, (int) ChronoUnit.DAYS.between(LocalDate.now(), project.getEndAt().toLocalDate()));
-		return NearDeadlineProjectResponse.of(project.getId(), project.getName(), project.getEndAt(), dday);
-	}
-
-	@Transactional(readOnly = true)
-	public Long countNearDeadlineProjectsByLoginMember(final NearDeadlineProjectRequest nearDeadlineProjectRequest, final LocalDate baseDate) {
-		final String memberRole = nearDeadlineProjectRequest.getMemberRole();
-
-		if (MemberRole.SYSTEM_ADMIN.getRoleName().equals(memberRole)) {
-			return projectRepository.countNearDeadlineProjects(baseDate);
-		}
-
-		if (MemberRole.CLIENT_ADMIN.getRoleName().equals(memberRole) || MemberRole.DEV_ADMIN.getRoleName().equals(
-			memberRole)) {
-			final UUID companyId = nearDeadlineProjectRequest.getCompanyId();
-			final List<ProjectAssign> assigns = projectAssignRepository.findAllByCompanyId(companyId, memberRole);
-			final List<UUID> projectIds = assigns.stream()
-				.map(ProjectAssign::getProjectId)
-				.toList();
-
-			return projectRepository.countNearDeadlineProjectsByProjectIds(projectIds, baseDate);
-		}
-
-		final UUID memberId = nearDeadlineProjectRequest.getMemberId();
-		final List<ProjectMember> projectMembers = projectMemberRepository.findAllByMemberId(memberId);
-		final List<UUID> projectIds = projectMembers.stream()
-			.map(ProjectMember::getProjectId)
-			.distinct()
-			.toList();
-
-		return projectRepository.countNearDeadlineProjectsByProjectIds(projectIds, baseDate);
-	}
-
-	@Transactional
 	public List<MyProjectSelectResponse> findProjectsByLoginMember(LoginMemberDetail loginMemberDetail){
 		String memberRole = loginMemberDetail.roleName();
 		UUID companyId = loginMemberDetail.companyId();
@@ -471,134 +347,5 @@ public class ProjectService {
 						project.getEndAt()
 				))
 				.toList();
-	}
-    @Transactional
-    public List<ProjectAmountSummaryResponse> findProjectAmountSummary(LoginMemberDetail memberDetail, String chartType, LocalDate today) {
-        //로그인한 유저의 타입별로 프로젝트 Ids를 반환Add commentMore actions
-        final List<UUID> projectIds = getProjectIdsByRoleName(memberDetail);
-        String status = "COMPLETED";
-
-        if (ProjectAmountChartRole.CHART_WEEK.isSameChartType(chartType)) {
-            //프로젝트 조회 (1달전의 주의 첫날 월요일 기준)
-            LocalDate oneMonthAgo = today.minusMonths(1);
-            LocalDate startOfWeek = oneMonthAgo.with(TemporalAdjusters.previousOrSame(DayOfWeek.SUNDAY));
-            LocalDateTime startDate = startOfWeek.atStartOfDay();
-
-            //프로젝트 날짜 기준으로 조회.
-            final List<Project> projects = projectRepository.findCompletedProjectsByIdsWithDate(projectIds, startDate,status);
-
-            List<ProjectAmountSummaryResponse> result = new ArrayList<>();
-
-            for (int i = 3; i >= 0; i--) {
-                LocalDateTime weekStart = startDate.plusWeeks(i);
-                //반복문은 7씩 증가 하지만 종료일은 오늘기준으로 가야함
-                LocalDateTime weekEnd = (i < 3) ? startDate.plusWeeks(i + 1) : today.atStartOfDay();
-                // 계산 통계 합계
-                long totalAmount = projects.stream()
-                        .filter(project -> {
-                            LocalDateTime endAt = project.getEndAt();
-                            return !endAt.isBefore(weekStart) && endAt.isBefore(weekEnd);
-                        })
-                        .mapToLong(Project::getProjectAmount)
-                        .sum();
-
-                //몇월인지 구함
-                int month = weekStart.getMonthValue();
-                //몇째 주 인지 구함
-                int weekOfMonth = weekStart.get(ChronoField.ALIGNED_WEEK_OF_MONTH);
-                String label = month + "월" + weekOfMonth + "주";
-
-                result.add(new ProjectAmountSummaryResponse(label, totalAmount));
-            }
-            return result;
-        }
-
-        if (ProjectAmountChartRole.CHART_MONTH.isSameChartType(chartType)) {
-            //프로젝트 월초 6개월 치 데이터
-            YearMonth sixMonthAgo = YearMonth.from(today).minusMonths(5);
-            LocalDate startOfMonth = sixMonthAgo.atDay(1);
-            LocalDateTime startDate = startOfMonth.atStartOfDay();
-            //프로젝트 날짜 기준으로 조회.
-            final List<Project> projects = projectRepository.findCompletedProjectsByIdsWithDate(projectIds, startDate,status);
-
-            List<ProjectAmountSummaryResponse> result = new ArrayList<>();
-
-
-            for (int i = 5; i >= 0; i--) {
-                YearMonth targetMonth = YearMonth.from(today).minusMonths(i);
-                LocalDateTime monthStart = targetMonth.atDay(1).atStartOfDay();            // 월의 시작일
-                LocalDateTime monthEnd = targetMonth.atEndOfMonth().plusDays(1).atStartOfDay(); // 다음 달 1일 00:00
-
-                // 계산 통계 합계
-                long totalAmount = projects.stream()
-                        .filter(project -> {
-                            LocalDateTime endAt = project.getEndAt();
-                            return !endAt.isBefore(monthStart) && endAt.isBefore(monthEnd);
-                        })
-                        .mapToLong(Project::getProjectAmount)
-                        .sum();
-
-                //몇월인지 구함
-                String label = targetMonth.getMonthValue() + "월";
-
-                result.add(new ProjectAmountSummaryResponse(label, totalAmount));
-            }
-            return result;
-
-        }
-        return Collections.emptyList();
-    }
-
-    private List<UUID> getProjectIdsByRoleName(LoginMemberDetail memberDetail) {
-        String roleName = memberDetail.roleName();
-        if (MemberRole.CLIENT_ADMIN.isSameRoleName(roleName) || MemberRole.DEV_ADMIN.isSameRoleName(roleName)) {
-            return projectAssignRepository.findCompanyProjectsByCompanyId(memberDetail.companyId(), roleName);
-        } else if (MemberRole.USER.isSameRoleName(roleName)) {
-            return projectMemberRepository.findProjectIdsByMemberId(memberDetail.memberId());
-        } else {
-            throw new MemberTypeNotFoundException(MemberErrorType.TYPE_NOT_FOUND);
-        }
-    }
-
-	public DashboardCountSummaryResponse getSummaryTotalCount(LoginMemberDetail loginMemberDetail) {
-
-		final String userType = loginMemberDetail.roleName();
-		final UUID companyId = loginMemberDetail.companyId();
-		final UUID memberId = loginMemberDetail.memberId();
-
-		if (MemberRole.SYSTEM_ADMIN.isSameRoleName(userType)) {
-
-			return fetchProjectSummaryByProjectIds(null);
-
-		} else if (MemberRole.DEV_ADMIN.isSameRoleName(userType) || MemberRole.CLIENT_ADMIN.isSameRoleName(userType)
-				&& companyId != null) {
-
-			final List<UUID> projectIds = projectAssignRepository.getCompanyAdminProjectIds(companyId, userType).stream()
-					.map(ProjectAssign::getProjectId)
-					.toList();
-
-			return fetchProjectSummaryByProjectIds(projectIds);
-
-		} else if (MemberRole.USER.isSameRoleName(userType) && memberId != null) {
-
-			final List<UUID> projectIds = projectMemberRepository.getUserProjectIds(memberId).stream()
-					.map(ProjectMember::getProjectId)
-					.toList();
-
-			return fetchProjectSummaryByProjectIds(projectIds);
-
-		} else {
-			throw new MemberTypeNotFoundException(MemberErrorType.TYPE_NOT_FOUND);
-		}
-	}
-
-	private DashboardCountSummaryResponse fetchProjectSummaryByProjectIds(List<UUID> projectIds){
-		LocalDateTime now = LocalDateTime.now();
-
-		Long totalCount = projectRepository.getSummaryProjectTotalCount(projectIds);
-		Long inProgressCount = projectRepository.getSummaryInProgressProjectTotalCount(projectIds, now);
-		Long completedCount = projectRepository.getSummaryCompletedProjectTotalCount(projectIds, now);
-
-		return new DashboardCountSummaryResponse(totalCount, inProgressCount, completedCount);
 	}
 }

--- a/src/main/java/kr/mywork/interfaces/dashboard/controller/DashboardController.java
+++ b/src/main/java/kr/mywork/interfaces/dashboard/controller/DashboardController.java
@@ -1,5 +1,14 @@
 package kr.mywork.interfaces.dashboard.controller;
 
+import java.time.LocalDate;
+import java.util.List;
+
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.Pattern;
 import kr.mywork.common.api.support.response.ApiResponse;
@@ -7,20 +16,18 @@ import kr.mywork.common.auth.components.annotation.LoginMember;
 import kr.mywork.common.auth.components.dto.LoginMemberDetail;
 import kr.mywork.domain.dashboard.service.dto.response.DashboardCountSummaryResponse;
 import kr.mywork.domain.dashboard.service.dto.response.DashboardPopularProjectsResponse;
-import kr.mywork.domain.project.service.ProjectService;
+import kr.mywork.domain.project.service.ProjectDashBoardService;
 import kr.mywork.domain.project.service.dto.request.NearDeadlineProjectRequest;
 import kr.mywork.domain.project.service.dto.response.NearDeadlineProjectResponse;
 import kr.mywork.domain.project.service.dto.response.ProjectAmountSummaryResponse;
-import kr.mywork.interfaces.dashboard.controller.dto.response.*;
+import kr.mywork.interfaces.dashboard.controller.dto.response.DashboardCountSummaryWebResponse;
+import kr.mywork.interfaces.dashboard.controller.dto.response.DashboardPopularProjectListWebResponse;
+import kr.mywork.interfaces.dashboard.controller.dto.response.DashboardPopularProjectWebResponse;
+import kr.mywork.interfaces.dashboard.controller.dto.response.NearDeadlineProjectListWebResponse;
+import kr.mywork.interfaces.dashboard.controller.dto.response.NearDeadlineProjectWebResponse;
+import kr.mywork.interfaces.dashboard.controller.dto.response.ProjectAmountChartWebResponse;
+import kr.mywork.interfaces.dashboard.controller.dto.response.ProjectAmountSummaryWebResponse;
 import lombok.RequiredArgsConstructor;
-import org.springframework.validation.annotation.Validated;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
-
-import java.time.LocalDate;
-import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
@@ -30,13 +37,13 @@ public class DashboardController {
 
 	private static final String AMOUNT_CHART_TYPE = "^(CHART_TYPE_WEEK|CHART_TYPE_MONTH)$";
 
-	private final ProjectService projectService;
+	private final ProjectDashBoardService projectDashboardService;
 
 	@GetMapping("/total-summary")
 	public ApiResponse<DashboardCountSummaryWebResponse> getDashboardTotalCount(
 			@LoginMember LoginMemberDetail loginMemberDetail) {
 
-		final DashboardCountSummaryResponse dashboardCountSummaryResponse = projectService.getSummaryTotalCount(loginMemberDetail);
+		final DashboardCountSummaryResponse dashboardCountSummaryResponse = projectDashboardService.getSummaryTotalCount(loginMemberDetail);
 
 		final DashboardCountSummaryWebResponse dashboardCountSummaryWebResponse = DashboardCountSummaryWebResponse.from(dashboardCountSummaryResponse);
 
@@ -48,7 +55,7 @@ public class DashboardController {
 	public    ApiResponse<DashboardPopularProjectListWebResponse> getMostPostProjectsTopFive(
 		@LoginMember final LoginMemberDetail memberDetail
 	){
-		final List<DashboardPopularProjectsResponse> popularProjects = projectService.getMostPostProjectsTopFive(memberDetail);
+		final List<DashboardPopularProjectsResponse> popularProjects = projectDashboardService.getMostPostProjectsTopFive(memberDetail);
 
 		final List<DashboardPopularProjectWebResponse> webResponse = popularProjects.stream()
 			.map(DashboardPopularProjectWebResponse::from)
@@ -75,10 +82,10 @@ public class DashboardController {
 		);
 
 		final List<NearDeadlineProjectResponse> NearDeadlineProjectResponse =
-			projectService.findNearDeadlineProjectsByLoginMember(page, nearDeadlineProjectWebRequest, today);
+			projectDashboardService.findNearDeadlineProjectsByLoginMember(page, nearDeadlineProjectWebRequest, today);
 
 		final long totalCount =
-			projectService.countNearDeadlineProjectsByLoginMember(nearDeadlineProjectWebRequest, today);
+			projectDashboardService.countNearDeadlineProjectsByLoginMember(nearDeadlineProjectWebRequest, today);
 
 		final List<NearDeadlineProjectWebResponse> nearDeadlineProjectWebResponses = NearDeadlineProjectResponse.stream()
 			.map(NearDeadlineProjectWebResponse::fromServiceResponse)
@@ -96,7 +103,7 @@ public class DashboardController {
 			@Pattern(regexp = AMOUNT_CHART_TYPE, message = "{dashboard.invalid.amount-char-type}") String chartType){
 		LocalDate today = LocalDate.now();
 		//날짜, totalCount
-		final List<ProjectAmountSummaryResponse> projectAmountSummaryList = projectService.findProjectAmountSummary(loginMemberDetail,chartType,today);
+		final List<ProjectAmountSummaryResponse> projectAmountSummaryList = projectDashboardService.findProjectAmountSummary(loginMemberDetail,chartType,today);
 
 		final List<ProjectAmountChartWebResponse> projectAmountChartWebResponses = projectAmountSummaryList.stream()
 				.map(ProjectAmountChartWebResponse::from)

--- a/src/test/java/kr/mywork/infrastructure/project/rdb/QueryDslProjectRepositoryTest.java
+++ b/src/test/java/kr/mywork/infrastructure/project/rdb/QueryDslProjectRepositoryTest.java
@@ -1,0 +1,63 @@
+package kr.mywork.infrastructure.project.rdb;
+
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.test.context.jdbc.Sql;
+
+import kr.mywork.base.annotations.RdbRepositoryTest;
+import kr.mywork.domain.project.model.Project;
+
+@RdbRepositoryTest(
+	basePackages = {
+		"kr.mywork.infrastructure.project.rdb",
+		"kr.mywork.common.rdb.config"})
+class QueryDslProjectRepositoryTest {
+
+	@Autowired
+	private QueryDslProjectRepository queryDslProjectRepository;
+
+	@Value("${dashboard.page.size}")
+	private int dashboardPageSize;
+
+	@Test
+	@DisplayName("프로젝트 5일 이내 마감 임박 목록 조회 성공")
+	@Sql("classpath:sql/projects_near_deadline02.sql")
+	void 프로젝트_5일_이내_마감_임박_목록_조회_성공() {
+		// given
+		final List<UUID> projectIds = List.of(
+			UUID.fromString("0197ce0a-0573-7aed-ac15-10384b9a21ec"),
+			UUID.fromString("0197ce0a-38b4-76d1-ba71-a3913e0373da"),
+			UUID.fromString("0197ce0a-b5fd-776e-a304-b90e2441b143"),
+			UUID.fromString("0197ce0a-d6e7-752e-97f6-765a92821508"),
+			UUID.fromString("0197ce0a-eba0-7601-9edf-2143363d3a4f"),
+			UUID.fromString("0197ce0a-fa9c-78e2-86c1-b280542ebcb0"));
+
+		final LocalDateTime baseDate = LocalDateTime.of(2025, 7, 3, 0, 0);
+
+		// when
+		final List<Project> deadLineProjects = queryDslProjectRepository.findAllNearDeadlineProjectsByProjectIds(
+			projectIds, 1, dashboardPageSize, baseDate);
+
+		// then
+		assertSoftly(softAssertion -> {
+			softAssertion.assertThat(deadLineProjects)
+				.extracting(Project::getEndAt)
+				.allSatisfy(endAt -> {
+					final LocalDateTime deadlineStartRange = baseDate.toLocalDate().atStartOfDay();
+					final LocalDateTime deadLineEndRange = baseDate.plusDays(5).toLocalDate().atTime(23, 59, 59);
+
+					softAssertion.assertThat(endAt)
+						.isAfterOrEqualTo(deadlineStartRange)
+						.isBeforeOrEqualTo(deadLineEndRange);
+				});
+		});
+	}
+}

--- a/src/test/resources/sql/projects_near_deadline02.sql
+++ b/src/test/resources/sql/projects_near_deadline02.sql
@@ -1,0 +1,20 @@
+-- 프로젝트
+INSERT INTO project (deleted, created_at, end_at, modified_at, start_at, id, name, step, detail, project_amount)
+VALUES (0, NOW(), '2025-07-01 14:00:00', NOW(), NOW(),
+        UUID_TO_BIN('0197ce0a-0573-7aed-ac15-10384b9a21ec'),
+        '프로젝트1', 'IN_PROGRESS', '프로젝트 상세 내용1.', 100),
+       (0, NOW(), '2025-07-02 14:00:00', NOW(), NOW(),
+        UUID_TO_BIN('0197ce0a-38b4-76d1-ba71-a3913e0373da'),
+        '프로젝트2', 'IN_PROGRESS', '프로젝트 상세 내용2.', 100),
+       (0, NOW(), '2025-07-07 14:00:00', NOW(), NOW(),
+        UUID_TO_BIN('0197ce0a-b5fd-776e-a304-b90e2441b143'),
+        '프로젝트7', 'IN_PROGRESS', '프로젝트 상세 내용8.', 100),
+       (0, NOW(), '2025-07-08 14:00:00', NOW(), NOW(),
+        UUID_TO_BIN('0197ce0a-d6e7-752e-97f6-765a92821508'),
+        '프로젝트8', 'IN_PROGRESS', '프로젝트 상세 내용8.', 100),
+       (0, NOW(), '2025-07-09 14:00:00', NOW(), NOW(),
+        UUID_TO_BIN('0197ce0a-eba0-7601-9edf-2143363d3a4f'),
+        '프로젝트9', 'IN_PROGRESS', '프로젝트 상세 내용9.', 100),
+       (0, NOW(), '2025-07-10 14:00:00', NOW(), NOW(),
+        UUID_TO_BIN('0197ce0a-fa9c-78e2-86c1-b280542ebcb0'),
+        '프로젝트10', 'IN_PROGRESS', '프로젝트 상세 내용10.', 100);


### PR DESCRIPTION
## 📌 개요

- 고객사 어드민 대시보드 접근 시 5일 이내 대시보드에서 6일 이전 내용이 조회되는 문제

## 🛠️ 변경 사항

- PostService & PostDashboardSerivce 분리
- querydsl where 절 조건 수정

## ✅ 주요 체크 포인트

- [ ] 운영 환경에서 정상 동작 여부 확인 필요

## 🔁 테스트 결과

- 해당 이슈 참고

## 🔗 연관된 이슈

- #316


## 📑 레퍼런스

- 없음