### PR TITLE
feat: 프로젝트 매니저 상태값 변경  기능 추가

### DIFF
--- a/src/main/java/kr/mywork/common/api/components/interceptor/PermissionCheckInterceptor.java
+++ b/src/main/java/kr/mywork/common/api/components/interceptor/PermissionCheckInterceptor.java
@@ -1,0 +1,68 @@
+package kr.mywork.common.api.components.interceptor;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import kr.mywork.common.api.support.response.ApiResponse;
+import kr.mywork.domain.auth.dto.MemberDetails;
+import kr.mywork.domain.member.model.MemberRole;
+import kr.mywork.domain.project.errors.ProjectErrorType;
+import kr.mywork.domain.project.model.ProjectMember;
+import kr.mywork.domain.project_member.service.ProjectMemberService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.servlet.HandlerInterceptor;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.Optional;
+import java.util.UUID;
+
+@Slf4j
+@RequiredArgsConstructor
+public class PermissionCheckInterceptor implements HandlerInterceptor {
+
+    private final ProjectMemberService projectMemberService;
+    private final ObjectMapper objectMapper;
+
+    @Override
+    public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) throws IOException {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+
+        MemberDetails memberDetails = (MemberDetails) authentication.getPrincipal();
+        UUID memberId = memberDetails.getId();
+        UUID projectId = UUID.fromString(request.getParameter("projectId"));
+        String memberRole = memberDetails.getAuthorityAsStr();
+
+
+        if(MemberRole.SYSTEM_ADMIN.isSameRoleName(memberRole)){
+            return true;
+        }
+
+        if (!request.getMethod().equalsIgnoreCase("GET")) {
+            Optional<ProjectMember> projectManager = projectMemberService.findProjectManagerByMemberIdAndProjectId(memberId, projectId);
+            if (projectManager.isEmpty()) {
+                writeErrorResponse(response);
+                return false;
+
+            }
+        }
+
+        return true;
+    }
+    private void writeErrorResponse(HttpServletResponse response) throws IOException {
+        response.setCharacterEncoding(StandardCharsets.UTF_8.name());
+        response.setStatus(HttpServletResponse.SC_FORBIDDEN);
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+
+        ApiResponse<?> apiResponse = ApiResponse.error(
+                ProjectErrorType.PROJECT_PERMISSION_NOT_FOUND.getCode().name(),
+                ProjectErrorType.PROJECT_PERMISSION_NOT_FOUND.getMessage()
+        );
+
+        objectMapper.writeValue(response.getWriter(), apiResponse);
+    }
+}

--- a/src/main/java/kr/mywork/common/api/config/WebConfig.java
+++ b/src/main/java/kr/mywork/common/api/config/WebConfig.java
@@ -1,13 +1,23 @@
 package kr.mywork.common.api.config;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import kr.mywork.common.api.components.interceptor.PermissionCheckInterceptor;
+import kr.mywork.domain.project_member.service.ProjectMemberService;
+import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.ResourceHandlerRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 @Configuration
+@RequiredArgsConstructor
 public class WebConfig implements WebMvcConfigurer {
+	private final ProjectMemberService projectMemberService;
+	private final ObjectMapper objectMapper;
+
+
 	@Override
 	public void addResourceHandlers(final ResourceHandlerRegistry registry) {
 		registry.addResourceHandler("/static/**").addResourceLocations("classpath:/static/");
@@ -26,5 +36,15 @@ public class WebConfig implements WebMvcConfigurer {
 					.allowCredentials(true); // 인증 정보 포함 허용
 			}
 		};
+	}
+
+	@Override
+	public void addInterceptors(InterceptorRegistry registry) {
+		registry.addInterceptor(permissionCheckInterceptor())
+				.addPathPatterns("/api/projects/project-status");
+	}
+	@Bean
+	public PermissionCheckInterceptor permissionCheckInterceptor(){
+		return new PermissionCheckInterceptor(projectMemberService,objectMapper);
 	}
 }

--- a/src/main/java/kr/mywork/domain/project/errors/ProjectErrorCode.java
+++ b/src/main/java/kr/mywork/domain/project/errors/ProjectErrorCode.java
@@ -3,5 +3,7 @@ package kr.mywork.domain.project.errors;
 public enum ProjectErrorCode {
 	ERROR_PROJECT01,    // 프로젝트를 찾을 수 없음 (예: 조회/수정/삭제 시)
 	ERROR_PROJECT02,     // 프로젝트 ID 생성/검증 과정에서 문제가 발생했을 때
-	ERROR_PROJECT03
+	ERROR_PROJECT03,
+	ERROR_PROJECT04
+
 }

--- a/src/main/java/kr/mywork/domain/project/errors/ProjectErrorType.java
+++ b/src/main/java/kr/mywork/domain/project/errors/ProjectErrorType.java
@@ -9,8 +9,10 @@ public enum ProjectErrorType {
 
 	PROJECT_NOT_FOUND(ProjectErrorCode.ERROR_PROJECT01, "해당 프로젝트를 찾을 수 없습니다."),
 	PROJECT_ID_NOT_FOUND(ProjectErrorCode.ERROR_PROJECT02, "유효한 프로젝트 ID가 아닙니다."),
-	PROJECT_ASSIGN_NOT_FOUND(ProjectErrorCode.ERROR_PROJECT03, "프로젝트 할당을 찾을 수 없습니다.");
+	PROJECT_ASSIGN_NOT_FOUND(ProjectErrorCode.ERROR_PROJECT03, "프로젝트 할당을 찾을 수 없습니다."),
+	PROJECT_PERMISSION_NOT_FOUND(ProjectErrorCode.ERROR_PROJECT04, "해당 프로젝트의 권한이 없습니다.");
 
 	private final ProjectErrorCode code;
 	private final String message;
+
 }

--- a/src/main/java/kr/mywork/domain/project/model/Project.java
+++ b/src/main/java/kr/mywork/domain/project/model/Project.java
@@ -90,4 +90,7 @@ public class Project {
 		this.deleted = request.deleted();
 		this.projectAmount = request.projectAmount();
 	}
+	public void updateStatus(String status){
+		this.step = status;
+	}
 }

--- a/src/main/java/kr/mywork/domain/project/model/ProjectMember.java
+++ b/src/main/java/kr/mywork/domain/project/model/ProjectMember.java
@@ -1,19 +1,17 @@
 package kr.mywork.domain.project.model;
 
-import java.time.LocalDateTime;
-import java.util.UUID;
-
-import org.hibernate.annotations.CreationTimestamp;
-import org.hibernate.annotations.UpdateTimestamp;
-
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
-
 import kr.mywork.common.rdb.id.UnixTimeOrderedUuidGeneratedValue;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
 
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -60,5 +58,9 @@ public class ProjectMember {
 
 	public void restore() {
 		this.deleted = false;
+	}
+
+	public void changeManager(Boolean isManager){
+		this.manager = !isManager;
 	}
 }

--- a/src/main/java/kr/mywork/domain/project/service/ProjectService.java
+++ b/src/main/java/kr/mywork/domain/project/service/ProjectService.java
@@ -601,4 +601,13 @@ public class ProjectService {
 
 		return new DashboardCountSummaryResponse(totalCount, inProgressCount, completedCount);
 	}
+	@Transactional
+	public UUID updateProjectStatus(UUID projectId, String status){
+		final Project project = projectRepository.findById(projectId)
+				.orElseThrow(() -> new ProjectNotFoundException(ProjectErrorType.PROJECT_NOT_FOUND));
+
+		project.updateStatus(status);
+
+		return project.getId();
+	}
 }

--- a/src/main/java/kr/mywork/domain/project_member/repository/ProjectMemberRepository.java
+++ b/src/main/java/kr/mywork/domain/project_member/repository/ProjectMemberRepository.java
@@ -15,4 +15,5 @@ public interface ProjectMemberRepository {
 	List<ProjectMember> findAllByMemberId(UUID memberId);
 	List<UUID> findProjectIdsByMemberId(UUID memberId);
 	List<ProjectMember> getUserProjectIds(UUID memberId);
+	Optional<ProjectMember> findProjectManagerByMemberIdAndProjectId (UUID memberId,UUID projectId);
 }

--- a/src/main/java/kr/mywork/domain/project_member/service/ProjectMemberService.java
+++ b/src/main/java/kr/mywork/domain/project_member/service/ProjectMemberService.java
@@ -15,6 +15,7 @@ import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 
 @Service
@@ -72,5 +73,24 @@ public class ProjectMemberService {
 		eventPublisher.publishEvent(new DeleteEventObject(projectMember, loginMemberDetail));
 
 		return projectMember.getId();
+	}
+	@Transactional
+	public Optional<ProjectMember> findProjectManagerByMemberIdAndProjectId(UUID memberId, UUID projectId){
+		return projectMemberRepository.findProjectManagerByMemberIdAndProjectId(memberId,projectId);
+	}
+
+	@Transactional
+	public UUID updateProjectManager(ProjectManagerUpdateRequest projectManagerUpdateRequest){
+		UUID memberId = projectManagerUpdateRequest.memberId();
+		UUID projectId = projectManagerUpdateRequest.projectId();
+
+		ProjectMember projectMember = projectMemberRepository.findByMemberIdAndProjectId(memberId, projectId)
+				.orElseThrow(() -> new ProjectMemberNotFoundException(ProjectMemberErrorType.PROJECT_MEMBER_NOT_FOUND));
+
+		//true -> false , false -> true
+		projectMember.changeManager(projectMember.getManager());
+
+
+		return projectMember.getMemberId();
 	}
 }

--- a/src/main/java/kr/mywork/domain/project_member/service/ProjectMemberService.java
+++ b/src/main/java/kr/mywork/domain/project_member/service/ProjectMemberService.java
@@ -8,6 +8,7 @@ import kr.mywork.domain.project.model.ProjectMember;
 import kr.mywork.domain.project_member.error.ProjectMemberErrorType;
 import kr.mywork.domain.project_member.error.ProjectMemberNotFoundException;
 import kr.mywork.domain.project_member.repository.ProjectMemberRepository;
+import kr.mywork.domain.project_member.service.dto.request.ProjectManagerUpdateRequest;
 import kr.mywork.domain.project_member.service.dto.response.CompanyMemberInProjectResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.ApplicationEventPublisher;

--- a/src/main/java/kr/mywork/domain/project_member/service/dto/request/ProjectManagerUpdateRequest.java
+++ b/src/main/java/kr/mywork/domain/project_member/service/dto/request/ProjectManagerUpdateRequest.java
@@ -1,0 +1,6 @@
+package kr.mywork.domain.project_member.service.dto.request;
+
+import java.util.UUID;
+
+public record ProjectManagerUpdateRequest(UUID memberId , UUID projectId) {
+}

--- a/src/main/java/kr/mywork/infrastructure/project_member/rdb/QueryDslProjectMemberRepository.java
+++ b/src/main/java/kr/mywork/infrastructure/project_member/rdb/QueryDslProjectMemberRepository.java
@@ -91,4 +91,16 @@ public class QueryDslProjectMemberRepository implements ProjectMemberRepository 
 				.fetch();
 	}
 
+	@Override
+	public Optional<ProjectMember> findProjectManagerByMemberIdAndProjectId(UUID memberId, UUID projectId) {
+		return Optional.ofNullable
+			(queryFactory
+				.selectFrom(projectMember)
+				.where(
+					projectMember.memberId.eq(memberId)
+						.and(projectMember.projectId.eq(projectId))
+						.and(projectMember.manager.isTrue())
+				).fetchOne());
+	}
+
 }

--- a/src/main/java/kr/mywork/interfaces/project/controller/ProjectController.java
+++ b/src/main/java/kr/mywork/interfaces/project/controller/ProjectController.java
@@ -132,4 +132,18 @@ public class ProjectController {
 
 		return ApiResponse.success(new MyProjectListWebResponse(webList));
 	}
+	@PostMapping("/project-status")
+	public ApiResponse<ProjectStatusUpdateWebResponse> updateProjectStatus(
+			@RequestParam UUID projectId,
+			@RequestParam(name = "status", required = false)
+			@Pattern(regexp = PROJECT_STEP_TYPE, message = "{project.invalid-status}") final String status
+	){
+		final UUID updatedProjectId = projectService.updateProjectStatus(projectId,status);
+
+		final ProjectStatusUpdateWebResponse projectStatusUpdateWebResponse =  new ProjectStatusUpdateWebResponse(updatedProjectId);
+
+		return ApiResponse.success(projectStatusUpdateWebResponse);
+
+	}
+
 }

--- a/src/main/java/kr/mywork/interfaces/project/controller/dto/response/ProjectStatusUpdateWebResponse.java
+++ b/src/main/java/kr/mywork/interfaces/project/controller/dto/response/ProjectStatusUpdateWebResponse.java
@@ -1,0 +1,6 @@
+package kr.mywork.interfaces.project.controller.dto.response;
+
+import java.util.UUID;
+
+public record ProjectStatusUpdateWebResponse(UUID projectId) {
+}

--- a/src/main/java/kr/mywork/interfaces/project_member/controller/ProjectMemberController.java
+++ b/src/main/java/kr/mywork/interfaces/project_member/controller/ProjectMemberController.java
@@ -4,8 +4,11 @@ import kr.mywork.common.api.support.response.ApiResponse;
 import kr.mywork.common.auth.components.annotation.LoginMember;
 import kr.mywork.common.auth.components.dto.LoginMemberDetail;
 import kr.mywork.domain.project_member.service.ProjectMemberService;
+import kr.mywork.domain.project_member.service.dto.request.ProjectManagerUpdateRequest;
 import kr.mywork.domain.project_member.service.dto.response.CompanyMemberInProjectResponse;
+import kr.mywork.interfaces.project_member.controller.dto.request.ProjectManagerUpdateWebRequest;
 import kr.mywork.interfaces.project_member.controller.dto.response.CompanyMembersInProjectWebResponse;
+import kr.mywork.interfaces.project_member.controller.dto.response.ProjectManagerUpdateWebResponse;
 import kr.mywork.interfaces.project_member.controller.dto.response.ProjectMemberAddWebResponse;
 import kr.mywork.interfaces.project_member.controller.dto.response.ProjectMemberDeleteWebResponse;
 import lombok.RequiredArgsConstructor;
@@ -55,6 +58,18 @@ public class ProjectMemberController {
 		final ProjectMemberDeleteWebResponse projectMemberDeleteWebResponse = new ProjectMemberDeleteWebResponse(deletedMemberId);
 
 		return ApiResponse.success(projectMemberDeleteWebResponse);
+	}
+	@PutMapping("/manager")
+	public ApiResponse<ProjectManagerUpdateWebResponse> projectManagerUpdateWebResponseApiResponse(
+			@RequestBody ProjectManagerUpdateWebRequest projectManagerUpdateWebRequest
+	){
+		final ProjectManagerUpdateRequest projectManagerUpdateRequest = projectManagerUpdateWebRequest.toServiceDto();
+
+		final UUID updatedManagerId = projectMemberService.updateProjectManager(projectManagerUpdateRequest);
+
+		final ProjectManagerUpdateWebResponse projectManagerUpdateWebResponse = new ProjectManagerUpdateWebResponse(updatedManagerId);
+
+		return ApiResponse.success(projectManagerUpdateWebResponse);
 	}
 }
 

--- a/src/main/java/kr/mywork/interfaces/project_member/controller/dto/request/ProjectManagerUpdateWebRequest.java
+++ b/src/main/java/kr/mywork/interfaces/project_member/controller/dto/request/ProjectManagerUpdateWebRequest.java
@@ -1,0 +1,16 @@
+package kr.mywork.interfaces.project_member.controller.dto.request;
+
+import kr.mywork.domain.project_member.service.dto.request.ProjectManagerUpdateRequest;
+
+import java.util.UUID;
+
+public record ProjectManagerUpdateWebRequest(UUID memberId , UUID projectId) {
+
+    public ProjectManagerUpdateRequest toServiceDto(){
+        return new ProjectManagerUpdateRequest(
+                this.memberId,
+                this.projectId
+        );
+
+    }
+}

--- a/src/main/java/kr/mywork/interfaces/project_member/controller/dto/response/ProjectManagerUpdateWebResponse.java
+++ b/src/main/java/kr/mywork/interfaces/project_member/controller/dto/response/ProjectManagerUpdateWebResponse.java
@@ -1,0 +1,6 @@
+package kr.mywork.interfaces.project_member.controller.dto.response;
+
+import java.util.UUID;
+
+public record ProjectManagerUpdateWebResponse(UUID memberId) {
+}

--- a/src/test/java/kr/mywork/docs/ProjectDocumentationTest.java
+++ b/src/test/java/kr/mywork/docs/ProjectDocumentationTest.java
@@ -388,4 +388,88 @@ public class ProjectDocumentationTest extends RestDocsDocumentation {
 								fieldWithPath("error").type(JsonFieldType.NULL).description("에러 정보"))
 						.build());
 	}
+	@Test
+	@DisplayName("프로젝트 스탭 변경")
+	@Sql("classpath:sql/project-status-update.sql")
+	void 내_프로젝트_스탭_변경_성공() throws Exception {
+		//given
+		final String accessToken = createSystemAccessToken();
+
+		final UUID projectId = UUID.fromString("01974f0b-5c7a-7fa2-9aba-1323490b77e9");
+
+		//when
+		final ResultActions result = mockMvc.perform(
+				post("/api/projects/project-status")
+						.param("projectId", projectId.toString())
+						.param("status","COMPLETED")
+						.contentType(MediaType.APPLICATION_JSON)
+						.header(HttpHeaders.AUTHORIZATION, toBearerAuthorizationHeader(accessToken)));
+
+		//then
+		result.andExpectAll(
+						status().isOk(),
+						jsonPath("$.result").value(ResultType.SUCCESS.name()),
+						jsonPath("$.data").exists(),
+						jsonPath("$.error").doesNotExist())
+				.andDo(document("project-update-status-success", projectUpdateStatusSuccessResource()));
+	}
+
+	private ResourceSnippet projectUpdateStatusSuccessResource() {
+		return resource(
+				ResourceSnippetParameters.builder()
+						.tag("Project API")
+						.summary("내 프로젝트 상태 변경 API")
+						.description("내 프로젝트 상태를 변경한다")
+						.requestHeaders(
+								headerWithName(HttpHeaders.CONTENT_TYPE).description("컨텐츠 타입"),
+								headerWithName(HttpHeaders.AUTHORIZATION).description("엑세스 토큰"))
+						.responseFields(
+								fieldWithPath("result").type(JsonFieldType.STRING).description("응답 결과"),
+								fieldWithPath("data.projectId").type(JsonFieldType.STRING).description("프로젝트 id"),
+								fieldWithPath("error").type(JsonFieldType.NULL).description("에러 정보"))
+						.build());
+	}
+	@Test
+	@DisplayName("프로젝트 스탭 변경 실패")
+	@Sql("classpath:sql/project-status-update.sql")
+	void 내_프로젝트_스탭_변경_실패() throws Exception {
+		//given
+		final String accessToken = createDevAdminAccessToken();
+
+		final UUID projectId = UUID.fromString("01974f0b-5c7a-7fa2-9aba-1323490b77e9");
+
+		//when
+		final ResultActions result = mockMvc.perform(
+				post("/api/projects/project-status")
+						.param("projectId", projectId.toString())
+						.param("status","COMPLETED")
+						.contentType(MediaType.APPLICATION_JSON)
+						.header(HttpHeaders.AUTHORIZATION, toBearerAuthorizationHeader(accessToken)));
+
+		//then
+		result.andExpectAll(
+						status().is4xxClientError(),
+						jsonPath("$.result").value(ResultType.ERROR.name()),
+						jsonPath("$.data").doesNotExist(),
+						jsonPath("$.error").exists())
+				.andDo(document("project-update-status-fail", projectUpdateStatusFailResource()));
+	}
+
+	private ResourceSnippet projectUpdateStatusFailResource() {
+		return resource(
+				ResourceSnippetParameters.builder()
+						.tag("Project API")
+						.summary("내 프로젝트 상태 변경 API")
+						.description("내 프로젝트 상태를 변경한다")
+						.requestHeaders(
+								headerWithName(HttpHeaders.CONTENT_TYPE).description("컨텐츠 타입"),
+								headerWithName(HttpHeaders.AUTHORIZATION).description("엑세스 토큰"))
+						.responseFields(
+								fieldWithPath("result").type(JsonFieldType.STRING).description("응답 결과"),
+								fieldWithPath("data").type(JsonFieldType.NULL).description("응답 데이터"),
+								fieldWithPath("error.code").type(JsonFieldType.STRING).description("에러 코드"),
+								fieldWithPath("error.message").type(JsonFieldType.STRING).description("에러 정보"),
+								fieldWithPath("error.data").type(JsonFieldType.NULL).description("에러 정보"))
+						.build());
+	}
 }

--- a/src/test/java/kr/mywork/docs/ProjectMemberDocumentationTest.java
+++ b/src/test/java/kr/mywork/docs/ProjectMemberDocumentationTest.java
@@ -150,4 +150,46 @@ public class ProjectMemberDocumentationTest extends RestDocsDocumentation {
 					fieldWithPath("error").type(JsonFieldType.NULL).description("에러 정보"))
 				.build());
 	}
+
+	@Test
+	@DisplayName("프로젝트 매니저 권한 수정 성공")
+	@Sql("classpath:sql/project-manager.sql")
+	void 프로젝트_매니저_권한_수정_성공() throws Exception {
+		// given
+		final String accessToken = createDevAdminAccessToken();
+
+		final UUID projectId = UUID.fromString("01974f0b-5c7a-7fa2-9aba-1323490b77e9");
+		final UUID memberId = UUID.fromString("019739ea-e7eb-76b7-b5e1-b9dc3ea1e9c2");
+
+		// when
+		final ResultActions result = mockMvc.perform(delete("/api/project-member")
+				.param("memberId", memberId.toString())
+				.param("projectId", projectId.toString())
+				.header(HttpHeaders.AUTHORIZATION, toBearerAuthorizationHeader(accessToken))
+				.contentType(MediaType.APPLICATION_JSON));
+
+		// then
+		result.andExpectAll(
+						status().isOk(),
+						jsonPath("$.result").value(ResultType.SUCCESS.name()),
+						jsonPath("$.data").exists(),
+						jsonPath("$.error").doesNotExist())
+				.andDo(document("project-manager-update-success", projectManagerUpdateSuccessResource()));
+	}
+
+	private ResourceSnippet projectManagerUpdateSuccessResource() {
+		return resource(
+				ResourceSnippetParameters.builder()
+						.tag("Project Member API")
+						.summary("프로젝트 매니저 권한 수정 API")
+						.description("프로젝트 매니저 권한 수정한다")
+						.requestHeaders(
+								headerWithName(HttpHeaders.CONTENT_TYPE).description("컨텐츠 타입"),
+								headerWithName(HttpHeaders.AUTHORIZATION).description("엑세스 토큰"))
+						.responseFields(
+								fieldWithPath("result").type(JsonFieldType.STRING).description("응답 결과"),
+								fieldWithPath("data.memberId").type(JsonFieldType.STRING).description("삭제된 프로젝트 멤버 아이디"),
+								fieldWithPath("error").type(JsonFieldType.NULL).description("에러 정보"))
+						.build());
+	}
 }

--- a/src/test/java/kr/mywork/interfaces/post/controller/PostControllerTest.java
+++ b/src/test/java/kr/mywork/interfaces/post/controller/PostControllerTest.java
@@ -3,6 +3,7 @@ package kr.mywork.interfaces.post.controller;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import kr.mywork.common.api.support.response.ResultType;
 import kr.mywork.domain.project.service.ProjectService;
+import kr.mywork.domain.project_member.service.ProjectMemberService;
 import kr.mywork.interfaces.project.controller.ProjectController;
 import kr.mywork.interfaces.project.controller.dto.request.ProjectCreateWebRequest;
 import org.junit.jupiter.api.DisplayName;
@@ -45,6 +46,9 @@ class PostControllerTest {
 
 	@MockitoBean
 	private ProjectService projectService;
+
+	@MockitoBean
+	private ProjectMemberService projectMemberService;
 
 	@Test
 	@DisplayName("프로젝트 생성 성공")

--- a/src/test/java/kr/mywork/interfaces/project_step/controller/ProjectStepControllerTest.java
+++ b/src/test/java/kr/mywork/interfaces/project_step/controller/ProjectStepControllerTest.java
@@ -3,6 +3,7 @@ package kr.mywork.interfaces.project_step.controller;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import kr.mywork.common.api.support.response.ResultType;
 import kr.mywork.domain.post.service.PostService;
+import kr.mywork.domain.project_member.service.ProjectMemberService;
 import kr.mywork.domain.project_step.serivce.ProjectStepService;
 import kr.mywork.domain.project_step.serivce.dto.response.ProjectStepUpdateResponse;
 import kr.mywork.interfaces.project_step.dto.request.ProjectStepCreateWebRequest;
@@ -54,6 +55,9 @@ class ProjectStepControllerTest {
 
 	@MockitoBean
 	private PostService postService;
+
+	@MockitoBean
+	private ProjectMemberService projectMemberService;
 
 	@Test
 	@DisplayName("프로젝트 단계 목록 생성 성공")

--- a/src/test/resources/sql/project-manager.sql
+++ b/src/test/resources/sql/project-manager.sql
@@ -1,0 +1,11 @@
+INSERT INTO project_member (id, project_id, member_id, manager, deleted, created_at, modified_at)
+VALUES
+    (
+        UUID_TO_BIN('01974f20-3bbe-7d0d-a27e-097667886779'),
+        UUID_TO_BIN('01974f0b-5c7a-7fa2-9aba-1323490b77e9'),
+        UUID_TO_BIN('019739ea-e7eb-76b7-b5e1-b9dc3ea1e9c2'),
+        0,
+        0,
+        NOW(),
+        NOW()
+    );

--- a/src/test/resources/sql/project-status-update.sql
+++ b/src/test/resources/sql/project-status-update.sql
@@ -1,0 +1,11 @@
+INSERT INTO project (id, name, start_at, end_at, step, created_at, modified_at, detail, deleted,project_amount)
+VALUES (UUID_TO_BIN('01974f0b-5c7a-7fa2-9aba-1323490b77e9'),
+        '고객사 개발 프로젝트',
+        NOW(),
+        NOW(),
+        'IN_PROGRESS',
+        NOW(),
+        NOW(),
+        '고객사의 웹페이지를 구성해주는 프로젝트입니다',
+        0,
+        0);


### PR DESCRIPTION
## 📌 개요

- 프로젝트 매니저 상태값 변경  기능 추가

## 🛠️ 변경 사항
- 프로젝트 매니저 상태값 변경  기능 추가
- 프로젝트 상태값 변경 api 추가 
- 프로젝트 상태값 변경에 대한 인터셉터 추가
- 프로젝트 인터셉터에 의한 수정.

## ✅ 주요 체크 포인트

- [ ] 프로젝트 권한별 상태값 수정.

## 🔁 테스트 결과

- post맨 테스트 
<img width="910" alt="image" src="https://github.com/user-attachments/assets/f47f5a02-3dc1-4706-95f2-7944cf2871b9" />


## 🔗 연관된 이슈
#317 
