### PR TITLE
[fix] companyType` 파라미터 누락 시 예외 발생 문제 수정 및 QueryDSL 조건 null-safe 처리(#320)

### DIFF
--- a/src/main/java/kr/mywork/infrastructure/company/rdb/QueryDslCompanyRepository.java
+++ b/src/main/java/kr/mywork/infrastructure/company/rdb/QueryDslCompanyRepository.java
@@ -46,8 +46,10 @@ public class QueryDslCompanyRepository implements CompanyRepository {
 	@Override
 	public List<CompanySelectResponse> findCompaniesBySearchConditionWithPaging(final int page,
 		final int companyPageSize,
-		final String companyType, final String keywordType, String keyword, Boolean deleted) {
-
+		final String companyType,
+		final String keywordType,
+		final String keyword,
+		final Boolean deleted) {
 		final int offset = (page - 1) * companyPageSize;
 
 		return queryFactory.select(Projections.constructor(CompanySelectResponse.class,
@@ -60,9 +62,10 @@ public class QueryDslCompanyRepository implements CompanyRepository {
 				company.createdAt))
 			.from(company)
 			.where(
-				company.type.stringValue().eq(companyType),
+				eqCompanyType(companyType),
 				eqDeleted(deleted),
-				containsKeyword(keywordType, keyword))
+				containsKeyword(keywordType, keyword)
+			)
 			.offset(offset)
 			.limit(companyPageSize)
 			.fetch();
@@ -92,7 +95,7 @@ public class QueryDslCompanyRepository implements CompanyRepository {
 		return queryFactory.select(company.id.count())
 			.from(company)
 			.where(
-				company.type.stringValue().eq(companyType),
+				eqCompanyType(companyType),
 				eqDeleted(deleted),
 				containsKeyword(keywordType, keyword))
 			.fetchOne();

--- a/src/main/java/kr/mywork/interfaces/company/controller/CompanyController.java
+++ b/src/main/java/kr/mywork/interfaces/company/controller/CompanyController.java
@@ -111,7 +111,7 @@ public class CompanyController {
 	@GetMapping
 	public ApiResponse<CompanyListWebResponse> findCompaniesByOffset(
 		@RequestParam(name = "page") @Min(value = 1, message = "{invalid.page-size}") final int page,
-		@RequestParam(name = "companyType") @Pattern(regexp = COMPANY_TYPE_REGX, message = "{invalid.company-type}") final String companyType,
+		@RequestParam(name = "companyType", required = false) @Pattern(regexp = COMPANY_TYPE_REGX, message = "{invalid.company-type}") final String companyType,
 		@RequestParam(name = "keyword", required = false) final String keyword,
 		@RequestParam(name = "keywordType", required = false) @Pattern(regexp = COMPANY_KEYWORD_TYPE, message = "{invalid.company-search-type}") final String keywordType,
 		@RequestParam(name = "deleted", required = false) final Boolean deleted


### PR DESCRIPTION
## 📌 개요

* 회사 목록 API에서 `companyType` 파라미터가 누락될 경우 예외가 발생하던 문제를 수정하였습니다.
* QueryDSL 조건절에서 `eq(null)` 호출로 인해 발생하던 런타임 오류를 방지하도록 수정하였습니다.

## 🛠️ 변경 사항

* `@RequestParam(name = "companyType")` → `@RequestParam(name = "companyType", required = false)`로 수정하여 파라미터 optional 처리
* `company.type.stringValue().eq(companyType)` → `eqCompanyType(companyType)` 메서드로 변경하여 null-safe 쿼리 적용
* `eqCompanyType(String companyType)` 메서드 추가: null일 경우 조건 생략 처리
* `countTotalCompaniesByCondition` 및 `findCompaniesBySearchConditionWithPaging`에서 위 조건 적용

## ✅ 주요 체크 포인트

* [ ] `companyType`을 전달하지 않아도 전체 목록이 정상 조회되는지
* [ ] QueryDSL 조건이 null-safe하게 작동하는지 (`eq(null)` 호출이 발생하지 않는지)
* [ ] 프론트와 기존 동작 호환성 유지 여부

## 🔁 테스트 결과

* `companyType` 없이 호출 시 전체 회사 목록 정상 조회됨
* 이전에 발생하던 `InvalidDataAccessApiUsageException: eq(null) is not allowed` 예외 재현되지 않음
* 프론트에서 페이지 로딩 및 필터링 동작 모두 정상 작동 확인

## 🔗 연관된 이슈

* 없음


## 📑 레퍼런스

* 없음