### PR TITLE
[refactor] 목록 조회 시 최신 생성순으로 정렬되도록 기준 수정(#322)

### DIFF
--- a/src/main/java/kr/mywork/domain/project/service/ProjectService.java
+++ b/src/main/java/kr/mywork/domain/project/service/ProjectService.java
@@ -131,7 +131,6 @@ public class ProjectService {
 				projectRepository.findAllByStepAndNameWithPaging(step, null, page, projectPageSize);
 
 			final List<UUID> projectIds = projects.stream().map(Project::getId).toList();
-			projects.sort(Comparator.comparing(Project::getId));
 
 			final Map<UUID, ProjectAssign> projectIdAssignMap =
 				transformProjectAssignMap(projectAssignRepository.findAllByProjectIds(projectIds));

--- a/src/main/java/kr/mywork/infrastructure/company/rdb/QueryDslCompanyRepository.java
+++ b/src/main/java/kr/mywork/infrastructure/company/rdb/QueryDslCompanyRepository.java
@@ -66,6 +66,7 @@ public class QueryDslCompanyRepository implements CompanyRepository {
 				eqDeleted(deleted),
 				containsKeyword(keywordType, keyword)
 			)
+			.orderBy(company.createdAt.desc())
 			.offset(offset)
 			.limit(companyPageSize)
 			.fetch();

--- a/src/main/java/kr/mywork/infrastructure/member/rdb/QueryDslMemberRepository.java
+++ b/src/main/java/kr/mywork/infrastructure/member/rdb/QueryDslMemberRepository.java
@@ -147,7 +147,7 @@ public class QueryDslMemberRepository implements MemberRepository {
 			.from(member)
 			.join(company).on(member.companyId.eq(company.id))
 			.where(builder)
-			.orderBy(member.id.desc())
+			.orderBy(member.createdAt.desc())
 			.offset(offset)
 			.limit(memberPageSize)
 			.fetch();

--- a/src/main/java/kr/mywork/infrastructure/project/rdb/QueryDslProjectRepository.java
+++ b/src/main/java/kr/mywork/infrastructure/project/rdb/QueryDslProjectRepository.java
@@ -80,6 +80,7 @@ public class QueryDslProjectRepository implements ProjectRepository {
 
 		return queryFactory.selectFrom(project)
 			.where(eqDeleted(false), eqProjectStep(step), containsProjectName(projectName))
+			.orderBy(project.createdAt.desc())
 			.limit(size)
 			.offset(offset)
 			.fetch();
@@ -189,6 +190,7 @@ public class QueryDslProjectRepository implements ProjectRepository {
 		return queryFactory
 			.selectFrom(project)
 			.where(project.id.in(projectIds))
+			.orderBy(project.createdAt.desc())
 			.fetch();
 	}
 

--- a/src/main/java/kr/mywork/infrastructure/project_checklist/rdb/QueryDslProjectCheckListRepository.java
+++ b/src/main/java/kr/mywork/infrastructure/project_checklist/rdb/QueryDslProjectCheckListRepository.java
@@ -71,6 +71,7 @@ public class QueryDslProjectCheckListRepository implements ProjectCheckListRepos
 			.from(projectCheckList)
 			.join(projectStep).on(projectCheckList.projectStepId.eq(projectStep.id))
 			.where(projectStep.projectId.eq(projectId), eqProjectStepId(projectStepId))
+			.orderBy(projectCheckList.createdAt.desc())
 			.fetch();
 	}
 


### PR DESCRIPTION
## 📌 개요

* 도메인 전반의 목록 조회 정렬 기준을 `id` 기준에서 `createdAt` 기준으로 변경하여, 최신 생성된 항목이 상단에 표시되도록 개선

---

## 🛠️ 변경 사항

* `member`, `project`, `projectCheckList`, `company` 등 목록 조회 쿼리에 `.orderBy(createdAt.desc())` 추가
* `project.id.in(...)` 조회 시에도 `createdAt.desc()` 기준 정렬 추가
* 기존 `id.desc()` 또는 정렬 없음 상태였던 쿼리들을 명시적 정렬로 변경

---

## ✅ 주요 체크 포인트

* [ ] 정렬 변경으로 인한 기존 UI 정렬 기대값과의 차이 여부
* [ ] createdAt 필드 누락 또는 null 가능성 존재 여부
* [ ] 정렬 기준 변경이 페이징에 미치는 영향 (특히 이전 페이지/다음 페이지 결과)

---

## 🔁 테스트 결과

* 프로젝트, 멤버, 체크리스트 등 주요 목록 API 호출 후 프론트에서 정렬 순서 확인
* 각 목록에서 최신 항목이 가장 상단에 표시되는지 확인
* 기존 기능 정상 동작 유지 확인

---

## 🔗 연관된 이슈

* 없음

## 📑 레퍼런스

* 없음