### PR TITLE
[fix] 프로젝트 post 토탈카운트 문제 동적쿼리 수정

### DIFF
--- a/src/main/java/kr/mywork/infrastructure/post/rdb/QueryDslPostRepository.java
+++ b/src/main/java/kr/mywork/infrastructure/post/rdb/QueryDslPostRepository.java
@@ -7,8 +7,8 @@ import kr.mywork.domain.post.model.Post;
 import kr.mywork.domain.post.repository.PostRepository;
 import kr.mywork.domain.post.service.dto.request.PostCreateRequest;
 import kr.mywork.domain.post.service.dto.response.PostSelectResponse;
-import kr.mywork.domain.project.service.dto.response.DashboardMostPostProjectResponse;
 import kr.mywork.domain.post.service.dto.response.PostTotalCountInStepResponse;
+import kr.mywork.domain.project.service.dto.response.DashboardMostPostProjectResponse;
 import kr.mywork.domain.project_step.model.ProjectStep;
 import lombok.RequiredArgsConstructor;
 import org.springframework.lang.Nullable;
@@ -18,6 +18,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
+import static com.querydsl.core.types.dsl.Expressions.booleanTemplate;
 import static kr.mywork.domain.post.model.QPost.post;
 import static kr.mywork.domain.project_step.model.QProjectStep.projectStep;
 
@@ -176,7 +177,7 @@ public class QueryDslPostRepository implements PostRepository {
 	// 동적 조건 메서드 추가
 	private BooleanExpression inProjectStepIds(List<ProjectStep> projectSteps) {
 		if (projectSteps == null || projectSteps.isEmpty()) {
-			return null;
+			return booleanTemplate("1 = 2");
 		}
 
 		List<UUID> projectStepIds = projectSteps.stream()


### PR DESCRIPTION
## 📌 개요

- 프로젝트 post 토탈카운트 문제 동적쿼리 수정

## 🛠️ 변경 사항
- 프로젝트 post 토탈카운트 문제 동적쿼리 수정
- 기존 쿼리 null 반환 조건 where 절 무시로인해 모든 post 갯수가 내려감.

## ✅ 주요 체크 포인트

- [ ] 신규생성 프로젝트에 대해서 페이징 안나오게 확인.

## 🔁 테스트 결과

- 화면 테스트.
- 
<img width="856" alt="image" src="https://github.com/user-attachments/assets/b6b7c612-9450-46e7-835f-7aa6f44ee947" />


## 🔗 연관된 이슈
#340 