### PR TITLE
[feat] SSE 메시지 안읽은 메시지 전달 방식 통일

### DIFF
--- a/src/main/java/kr/mywork/domain/notification/listener/event/NotificationTxEventListener.java
+++ b/src/main/java/kr/mywork/domain/notification/listener/event/NotificationTxEventListener.java
@@ -24,8 +24,8 @@ public class NotificationTxEventListener {
 	@Transactional(propagation = Propagation.REQUIRES_NEW)
 	@TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
 	public void handleNotificationCreateEvent(final NotificationCreateEvent event) {
-		realTimeNotificationService.sendNotification(event.authorId(), "review-notification", event);
-		log.info("saved notification content: {}", event);
+		long unreadCount = notificationService.countUnreadNotifications(event.authorId());
+		realTimeNotificationService.sendNotification(event.authorId(), "notification-unread-count", unreadCount);
 		saveNotification(event);
 	}
 

--- a/src/main/java/kr/mywork/domain/post/listener/PostApprovalNotificationTxListener.java
+++ b/src/main/java/kr/mywork/domain/post/listener/PostApprovalNotificationTxListener.java
@@ -23,7 +23,8 @@ public class PostApprovalNotificationTxListener {
 	@Async("eventTaskExecutor")
 	@TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
 	public void handlePostApprovalAlarmEvent(final PostApprovalNotificationEvent event) {
-		realTimeNotificationService.sendNotification(event.authorId(), "notification-post-approval", event);
+		final long unreadCount = notificationService.countUnreadNotifications(event.authorId());
+		realTimeNotificationService.sendNotification(event.authorId(), "notification-unread-count", unreadCount);
 		saveNotification(event);
 	}
 

--- a/src/main/java/kr/mywork/domain/project_checklist/listener/CheckListNotificationTxListener.java
+++ b/src/main/java/kr/mywork/domain/project_checklist/listener/CheckListNotificationTxListener.java
@@ -23,7 +23,8 @@ public class CheckListNotificationTxListener {
 	@TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
 	@Transactional(propagation = Propagation.REQUIRES_NEW)
 	public void handleCheckListCreatedHistory(final CheckListApprovalNotificationEvent event) {
-		realTimeNotificationService.sendNotification(event.authorId(), "notification-checklist-approval", event);
+		final long unreadCount = notificationService.countUnreadNotifications(event.authorId());
+		realTimeNotificationService.sendNotification(event.authorId(), "notification-unread-count", unreadCount);
 		saveNotification(event);
 	}
 

--- a/src/main/java/kr/mywork/interfaces/notification/controller/RealNotificationController.java
+++ b/src/main/java/kr/mywork/interfaces/notification/controller/RealNotificationController.java
@@ -21,11 +21,12 @@ public class RealNotificationController {
 	private final RealTimeNotificationService realTimeNotificationService;
 	private final NotificationService notificationService;
 
-	@GetMapping( value = "/real-notifications/connect", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
+	@GetMapping(value = "/real-notifications/connect", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
 	public ResponseEntity<SseEmitter> connectForRealTimeNotification(@LoginMember LoginMemberDetail loginMemberDetail) {
 		final SseEmitter sseEmitter = realTimeNotificationService.addSseEmitter(loginMemberDetail.memberId());
-		long count = notificationService.countUnreadNotifications(loginMemberDetail.memberId());
-		realTimeNotificationService.sendNotification(loginMemberDetail.memberId(), "notification-unread-count", count);
+		long unreadCount = notificationService.countUnreadNotifications(loginMemberDetail.memberId());
+		realTimeNotificationService.sendNotification(loginMemberDetail.memberId(), "notification-unread-count",
+			unreadCount);
 		return ResponseEntity.ok(sseEmitter);
 	}
 


### PR DESCRIPTION
## 📌 개요

- SSE 메시지 안읽은 메시지 전달 방식 통일

## 🛠️ 변경 사항

- SSE 알림 안읽은 메시지 갯수 전달 방식 통일

## ✅ 주요 체크 포인트

- [x] SSE 메시지로 같은 event-name 의 메시지가 전달되고 있는지 확인


## 🔁 테스트 결과

- 로컬 환경에서 테스트 및 확인 완료

<img width="716" alt="image" src="https://github.com/user-attachments/assets/585179eb-d35e-4017-93d7-efd179aaf6d8" />


## 🔗 연관된 이슈

#332 

<br>

## 📑 레퍼런스

- 없음