### PR TITLE
[feat] Spring 컨테이너 포트 변경, Grafana 포트 변경, Dockerfile base image slim 전환, k6 스크립트 비밀번호 하드코딩

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,5 +1,5 @@
 # 베이스 이미지
-FROM openjdk:17-jdk-alpine
+FROM openjdk:17-jdk-slim
 
 # 작업 디렉토리 설정
 WORKDIR /app

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -6,7 +6,7 @@ services:
       dockerfile: docker/Dockerfile
     container_name: mywork-application
     ports:
-      - "8080:8080"
+      - "8081:8080"
     environment:
       - SPRING_PROFILES_ACTIVE=local
     deploy:
@@ -66,7 +66,7 @@ services:
     image: grafana/grafana:11.5.6
     container_name: grafana
     ports:
-      - "3000:3000"
+      - "3001:3000"
     volumes:
       - ../grafana-data:/var/lib/grafana
     environment:

--- a/k6/member/MemberLoadTest.js
+++ b/k6/member/MemberLoadTest.js
@@ -19,7 +19,7 @@ export default function() {
 
     let response = loginMember({
       email: user.email,
-      password: user.password
+      password: '1234'
     });
 
     check(response, {


### PR DESCRIPTION
## 📌 개요

- 부하테스트와 로컬 개발 환경 충돌을 방지하고, ARM(M1) 환경 호환성 확보 및 테스트 편의성을 위해 여러 설정을 변경했습니다.

## 🛠️ 변경 사항

- Spring 컨테이너 포트를 8080 -> 8081로 변경 (로컬 IntelliJ에서 실행되는 서버와 충돌 방지)
- Grafana 포트를 3000 → 3001로 변경 (프론트 로컬 개발 서버 포트와 충돌 방지)
- Dockerfile base image를 `openjdk:17-jdk-alpine` → `openjdk:17-jdk-slim`으로 변경 (M1 환경 호환성)
- k6 부하테스트 스크립트에서 비밀번호를 `1234`로 하드코딩 (테스트 DB의 해시된 비밀번호와 일치)

## ✅ 주요 체크 포인트

- [x] Docker 컨테이너와 로컬 환경이 정상적으로 함께 실행되는지
- [x] M1, Intel 환경 모두에서 컨테이너 빌드 및 실행 가능 여부
- [x] k6 부하테스트 스크립트 실행 시 로그인/인증 정상 동작 확인

## 🔁 테스트 결과

- 도커 컨테이너 기동 시 IntelliJ 로컬 Spring 서버와 충돌 없이 동시 실행 가능 확인
- Docker 이미지 빌드 및 기동이 M1, Intel 환경 모두에서 정상 동작 확인
- k6 부하테스트 스크립트에서 로그인 요청이 DB에 등록된 테스트 계정(`1234` 비밀번호)으로 성공적으로 수행됨

## 🔗 연관된 이슈
- #348 
