### PR TITLE
feat :  업체 내 사원 이름 검색  추가 

### DIFF
--- a/src/main/java/kr/mywork/domain/member/repository/MemberRepository.java
+++ b/src/main/java/kr/mywork/domain/member/repository/MemberRepository.java
@@ -1,19 +1,19 @@
 package kr.mywork.domain.member.repository;
 
-import java.util.List;
-import java.util.Optional;
-import java.util.UUID;
-
 import kr.mywork.domain.company.service.dto.response.MemberDetailResponse;
 import kr.mywork.domain.member.model.Member;
 import kr.mywork.domain.member.service.dto.response.MemberSelectResponse;
 
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
 public interface MemberRepository {
 	Optional<Member> findByEmailAndDeletedFalse(String email);
 
-	List<Member> findMemberByCompanyId(UUID companyId, int page, int memberPageSize);
+	List<Member> findMemberByCompanyId(UUID companyId, int page, int memberPageSize, String memberName);
 
-	long countByCompanyIdAndDeletedFalse(UUID companyId);
+	long countByCompanyIdAndDeletedFalse(UUID companyId,String memberName);
 
 	Member save(Member member);
 

--- a/src/main/java/kr/mywork/domain/member/service/MemberService.java
+++ b/src/main/java/kr/mywork/domain/member/service/MemberService.java
@@ -1,16 +1,5 @@
 package kr.mywork.domain.member.service;
 
-import java.time.format.DateTimeFormatter;
-import java.util.List;
-import java.util.UUID;
-import java.util.stream.Collectors;
-
-import org.springframework.beans.factory.annotation.Value;
-import org.springframework.context.ApplicationEventPublisher;
-import org.springframework.security.crypto.password.PasswordEncoder;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
-
 import kr.mywork.common.auth.components.dto.LoginMemberDetail;
 import kr.mywork.domain.activityLog.listener.eventObject.ActivityLogCreateEvent;
 import kr.mywork.domain.activityLog.listener.eventObject.ActivityLogDeleteEvent;
@@ -25,6 +14,16 @@ import kr.mywork.domain.member.service.dto.response.CompanyMemberResponse;
 import kr.mywork.domain.member.service.dto.response.MemberSelectResponse;
 import kr.mywork.interfaces.member.controller.dto.request.ResetPasswordWebRequest;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+import java.util.UUID;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -38,9 +37,9 @@ public class MemberService {
 	private final ApplicationEventPublisher eventPublisher;
 
 	@Transactional
-	public List<CompanyMemberResponse> findMemberByCompanyId(UUID companyId, int page) {
+	public List<CompanyMemberResponse> findMemberByCompanyId(UUID companyId, int page, String memberName) {
 
-		return memberRepository.findMemberByCompanyId(companyId, page, memberPageSize)
+		return memberRepository.findMemberByCompanyId(companyId, page, memberPageSize, memberName)
 			.stream()
 			.map(CompanyMemberResponse::fromEntity)
 			.collect(Collectors.toList());
@@ -48,8 +47,8 @@ public class MemberService {
 	}
 
 	@Transactional
-	public long countMembersByCompanyId(UUID companyId) {
-		return memberRepository.countByCompanyIdAndDeletedFalse(companyId);
+	public long countMembersByCompanyId(UUID companyId, String memberName) {
+		return memberRepository.countByCompanyIdAndDeletedFalse(companyId,memberName);
 	}
 
 	@Transactional

--- a/src/main/java/kr/mywork/interfaces/company/controller/CompanyController.java
+++ b/src/main/java/kr/mywork/interfaces/company/controller/CompanyController.java
@@ -1,19 +1,5 @@
 package kr.mywork.interfaces.company.controller;
 
-import java.util.List;
-import java.util.UUID;
-
-import org.springframework.validation.annotation.Validated;
-import org.springframework.web.bind.annotation.DeleteMapping;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.PutMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
-
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.Pattern;
 import kr.mywork.common.api.support.response.ApiResponse;
@@ -29,18 +15,15 @@ import kr.mywork.domain.member.service.MemberService;
 import kr.mywork.domain.member.service.dto.response.CompanyMemberResponse;
 import kr.mywork.interfaces.company.controller.dto.request.CompanyCreateWebRequest;
 import kr.mywork.interfaces.company.controller.dto.request.CompanyUpdateWebRequest;
-import kr.mywork.interfaces.company.controller.dto.response.CompanyCreateWebResponse;
-import kr.mywork.interfaces.company.controller.dto.response.CompanyDeleteWebResponse;
-import kr.mywork.interfaces.company.controller.dto.response.CompanyDetailWebResponse;
-import kr.mywork.interfaces.company.controller.dto.response.CompanyIdCreateWebResponse;
-import kr.mywork.interfaces.company.controller.dto.response.CompanyListWebResponse;
-import kr.mywork.interfaces.company.controller.dto.response.CompanyNameWebResponse;
-import kr.mywork.interfaces.company.controller.dto.response.CompanyNamesWebResponse;
-import kr.mywork.interfaces.company.controller.dto.response.CompanySelectWebResponse;
-import kr.mywork.interfaces.company.controller.dto.response.CompanyUpdateWebResponse;
+import kr.mywork.interfaces.company.controller.dto.response.*;
 import kr.mywork.interfaces.member.controller.dto.response.CompanyMemberListWebResponse;
 import kr.mywork.interfaces.member.controller.dto.response.CompanyMemberWebResponse;
 import lombok.RequiredArgsConstructor;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import java.util.UUID;
 
 @RestController
 @RequiredArgsConstructor
@@ -141,11 +124,14 @@ public class CompanyController {
 	}
 
 	@GetMapping("/{companyId}/members")
-	public ApiResponse<CompanyMemberWebResponse> getCompanyMember(@PathVariable(name = "companyId") UUID companyId,
-		@RequestParam(defaultValue = "1") @Min(value = 1, message = "{invalid.page-size}") int page) {
-		List<CompanyMemberResponse> companyMemberResponses = memberService.findMemberByCompanyId(companyId, page);
+	public ApiResponse<CompanyMemberWebResponse> getCompanyMember(
+			@PathVariable(name = "companyId") UUID companyId,
+			@RequestParam(defaultValue = "1") @Min(value = 1, message = "{invalid.page-size}") int page,
+			@RequestParam(name = "memberName", required = false) final String memberName
+	) {
+		List<CompanyMemberResponse> companyMemberResponses = memberService.findMemberByCompanyId(companyId, page,memberName);
 
-		long total = memberService.countMembersByCompanyId(companyId);
+		long total = memberService.countMembersByCompanyId(companyId,memberName);
 
 		List<CompanyMemberListWebResponse> companyMemberWebResponses = companyMemberResponses.stream()
 			.map(CompanyMemberListWebResponse::fromService)

--- a/src/test/java/kr/mywork/docs/CompanyDocumentationTest.java
+++ b/src/test/java/kr/mywork/docs/CompanyDocumentationTest.java
@@ -1,19 +1,11 @@
 package kr.mywork.docs;
 
-import static com.epages.restdocs.apispec.MockMvcRestDocumentationWrapper.document;
-import static com.epages.restdocs.apispec.ResourceDocumentation.headerWithName;
-import static com.epages.restdocs.apispec.ResourceDocumentation.parameterWithName;
-import static com.epages.restdocs.apispec.ResourceDocumentation.resource;
-import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.delete;
-import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
-import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
-import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.put;
-import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
-
-import java.util.UUID;
-
+import com.epages.restdocs.apispec.ResourceSnippet;
+import com.epages.restdocs.apispec.ResourceSnippetParameters;
+import com.fasterxml.uuid.Generators;
+import kr.mywork.common.api.support.response.ResultType;
+import kr.mywork.interfaces.company.controller.dto.request.CompanyCreateWebRequest;
+import kr.mywork.interfaces.company.controller.dto.request.CompanyUpdateWebRequest;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpHeaders;
@@ -23,13 +15,14 @@ import org.springframework.restdocs.payload.JsonFieldType;
 import org.springframework.test.context.jdbc.Sql;
 import org.springframework.test.web.servlet.ResultActions;
 
-import com.epages.restdocs.apispec.ResourceSnippet;
-import com.epages.restdocs.apispec.ResourceSnippetParameters;
-import com.fasterxml.uuid.Generators;
+import java.util.UUID;
 
-import kr.mywork.common.api.support.response.ResultType;
-import kr.mywork.interfaces.company.controller.dto.request.CompanyCreateWebRequest;
-import kr.mywork.interfaces.company.controller.dto.request.CompanyUpdateWebRequest;
+import static com.epages.restdocs.apispec.MockMvcRestDocumentationWrapper.document;
+import static com.epages.restdocs.apispec.ResourceDocumentation.*;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.*;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 public class CompanyDocumentationTest extends RestDocsDocumentation {
 
@@ -464,6 +457,7 @@ public class CompanyDocumentationTest extends RestDocsDocumentation {
 		final ResultActions result = mockMvc.perform(
 			get("/api/companies/{companyId}/members", id)
 				.param("page", "1")
+				.param("memberName","김민수")
 				.contentType(MediaType.APPLICATION_JSON)
 				.header(HttpHeaders.AUTHORIZATION, toBearerAuthorizationHeader(accessToken)));
 
@@ -483,7 +477,8 @@ public class CompanyDocumentationTest extends RestDocsDocumentation {
 				.summary("회사의 직원 목록 조회 API")
 				.description("회사의 직원 목록을 조회한다.")
 				.queryParameters(
-					parameterWithName("page").description("페이지 번호"))
+					parameterWithName("page").description("페이지 번호"),
+					parameterWithName("memberName").optional().description("이름 검색어 (부분 일치 검색)"))
 				.requestHeaders(
 					headerWithName(HttpHeaders.CONTENT_TYPE).description("컨텐츠 타입"),
 					headerWithName(HttpHeaders.AUTHORIZATION).description("엑세스 토큰"))


### PR DESCRIPTION
## 📌 개요

- 업체 내 사원 이름 검색  추가 

## 🛠️ 변경 사항
- 업체 내 사원 이름 검색  추가 

## ✅ 주요 체크 포인트

- [ ] 회사내 상세 페이지에 직원 검색 기능 추가

## 🔁 테스트 결과

- 통합테스트
![image](https://github.com/user-attachments/assets/4b91d940-3f30-4f60-b72c-fedc8d16173a)


## 🔗 연관된 이슈
#350 
