### PR TITLE
bug: 트랜잭션 어노테이션에 readOnly 옵션 제거

### DIFF
--- a/src/main/java/kr/mywork/domain/company/service/CompanyImageService.java
+++ b/src/main/java/kr/mywork/domain/company/service/CompanyImageService.java
@@ -29,7 +29,7 @@ public class CompanyImageService {
 	private final CompanyRepository companyRepository;
 	private final CompanyImageFileHandler companyImageFileHandler;
 
-	@Transactional(readOnly = true)
+	@Transactional
 	public CompanyImageUploadUrlIssueResponse issueCompanyImageUploadUrl(final UUID companyId, final String fileName) {
 		final Optional<Company> companyOptional = companyRepository.findById(companyId);
 


### PR DESCRIPTION
## 📌 개요

- 트랜잭션 어노테이션에 readOnly 옵션 제거합니다.

## 🛠️ 변경 사항
- company 테이블에 이미지 이름이 저장이 안되어서 보니 readonly 옵션이 들어가있어서 제거 하였습니다. 

## ✅ 주요 체크 포인트


## 🔁 테스트 결과


## 🔗 연관된 이슈
- #355 